### PR TITLE
Phase H: Compiler Type Safety - Exhaustive Jump Target Handling

### DIFF
--- a/src/compiler/emitter.rs
+++ b/src/compiler/emitter.rs
@@ -42,87 +42,153 @@ impl BytecodeEmitter {
         self.operations.len()
     }
 
-    /// Resolve a label to a JumpTarget.
-    /// If the label is already bound, returns Resolved; otherwise Unresolved.
-    fn resolve_label(&self, label: Label) -> JumpTarget {
-        let Label(id) = label;
-        match self.label_positions.get(id).and_then(|pos| *pos) {
-            Some(addr) => JumpTarget::Resolved(addr),
-            None => JumpTarget::Unresolved(label),
-        }
-    }
-
     /// Emit an operation at the current position.
     pub fn emit(&mut self, op: Operation) {
         self.operations.push(op);
     }
 
     /// Emit a GoTo instruction to the given label.
+    /// Label resolution is deferred until finalize().
     pub fn emit_goto(&mut self, label: Label) {
-        let target = self.resolve_label(label);
-        self.operations.push(Operation::GoTo(target));
+        self.operations.push(Operation::GoTo(JumpTarget::Unresolved(label)));
     }
 
     /// Emit a GoToIfFalse instruction: jump to label if register is false.
+    /// Label resolution is deferred until finalize().
     pub fn emit_goto_if_false(&mut self, label: Label, reg: Reg) {
-        let target = self.resolve_label(label);
-        self.operations.push(Operation::GoToIfFalse(target, reg));
+        self.operations.push(Operation::GoToIfFalse(JumpTarget::Unresolved(label), reg));
     }
 
     /// Emit a GoToIfEqualValue instruction: jump to label if lhs == rhs.
+    /// Label resolution is deferred until finalize().
     pub fn emit_goto_if_equal(&mut self, label: Label, lhs: Reg, rhs: Reg) {
-        let target = self.resolve_label(label);
         self.operations
-            .push(Operation::GoToIfEqualValue(target, lhs, rhs));
+            .push(Operation::GoToIfEqualValue(JumpTarget::Unresolved(label), lhs, rhs));
     }
 
     /// Emit a PopKey instruction: pop key from list into dest, or jump if empty.
+    /// Label resolution is deferred until finalize().
     pub fn emit_pop_key(&mut self, dest: Reg, list: Reg, label: Label) {
-        let target = self.resolve_label(label);
-        self.operations.push(Operation::PopKey(dest, list, target));
+        self.operations.push(Operation::PopKey(dest, list, JumpTarget::Unresolved(label)));
     }
 
-    /// Finalize the bytecode by resolving all jump targets.
+    /// Finalize the bytecode by resolving all jump targets with an offset added.
     /// Returns the final list of operations.
     /// Panics if any label was never bound.
-    pub fn finalize(mut self) -> Vec<Operation> {
+    ///
+    /// The offset parameter is added to all resolved addresses, allowing code blocks
+    /// to be concatenated without a separate adjustment pass. For standalone code,
+    /// use `finalize()` which calls this with offset=0.
+    ///
+    /// This function is intentionally exhaustive - it explicitly matches every Operation variant.
+    /// When a new operation with a JumpTarget is added, this function will fail to compile,
+    /// ensuring that jump target resolution is not forgotten.
+    pub fn finalize_with_offset(mut self, offset: usize) -> Vec<Operation> {
         let label_positions = &self.label_positions;
 
-        // Resolve all unresolved jump targets
+        // Resolve all unresolved jump targets, adding offset to final addresses
         for op in &mut self.operations {
             match op {
+                // === Operations with JumpTarget - resolve unresolved labels ===
                 Operation::GoTo(ref mut target) => {
-                    *target = resolve_target(target, label_positions);
+                    *target = resolve_target_with_offset(target, label_positions, offset);
                 }
                 Operation::GoToIfFalse(ref mut target, _) => {
-                    *target = resolve_target(target, label_positions);
+                    *target = resolve_target_with_offset(target, label_positions, offset);
                 }
                 Operation::GoToIfEqualValue(ref mut target, _, _) => {
-                    *target = resolve_target(target, label_positions);
+                    *target = resolve_target_with_offset(target, label_positions, offset);
                 }
                 Operation::PopKey(_, _, ref mut target) => {
-                    *target = resolve_target(target, label_positions);
+                    *target = resolve_target_with_offset(target, label_positions, offset);
                 }
                 Operation::YieldFromRowBuffer(_, _, ref mut target) => {
-                    *target = resolve_target(target, label_positions);
+                    *target = resolve_target_with_offset(target, label_positions, offset);
                 }
                 Operation::YieldFromGroupTable(_, _, ref mut target) => {
-                    *target = resolve_target(target, label_positions);
+                    *target = resolve_target_with_offset(target, label_positions, offset);
                 }
-                _ => {}
+
+                // === Operations without JumpTarget - explicit no-op ===
+                // Value operations
+                Operation::StoreValue(_, _)
+                | Operation::IncrementValue(_)
+                | Operation::DecrementValue(_)
+                | Operation::AddValue(_, _, _)
+                | Operation::SubtractValue(_, _, _)
+                | Operation::MultiplyValue(_, _, _)
+                | Operation::DivideValue(_, _, _)
+                | Operation::RemainderValue(_, _, _)
+                | Operation::LessThanValue(_, _, _)
+                | Operation::LessThanOrEqualValue(_, _, _)
+                | Operation::GreaterThanValue(_, _, _)
+                | Operation::GreaterThanOrEqualValue(_, _, _)
+                | Operation::EqualsValue(_, _, _)
+                | Operation::NotEqualsValue(_, _, _)
+                | Operation::AndValue(_, _, _)
+                | Operation::OrValue(_, _, _)
+                | Operation::NotValue(_, _)
+                | Operation::NegateValue(_, _)
+                | Operation::CopyValue(_, _)
+                // String/Scalar function operations
+                | Operation::LengthValue(_, _)
+                | Operation::UpperValue(_, _)
+                | Operation::LowerValue(_, _)
+                | Operation::AbsValue(_, _)
+                | Operation::LikeValue(_, _, _)
+                // Key list operations
+                | Operation::InitKeyList(_)
+                | Operation::AppendKey(_, _)
+                // Row buffer operations
+                | Operation::InitRowBuffer(_)
+                | Operation::AppendToRowBuffer(_, _)
+                | Operation::SortRowBuffer(_, _)
+                // Group table operations
+                | Operation::InitGroupTable(_)
+                | Operation::UpdateGroup(_, _, _)
+                // Database operations
+                | Operation::Open(_, _)
+                | Operation::MoveCursor(_, _)
+                | Operation::ReadCursor(_, _)
+                | Operation::ReadKey(_, _)
+                | Operation::WriteCursor(_, _, _)
+                | Operation::DeleteCursor(_)
+                | Operation::CanReadCursor(_, _)
+                // Control flow operations (without jump targets)
+                | Operation::Yield(_)
+                | Operation::Halt => {
+                    // No jump targets to resolve
+                }
             }
         }
         self.operations
     }
+
+    /// Finalize the bytecode by resolving all jump targets.
+    /// Equivalent to `finalize_with_offset(0)`.
+    pub fn finalize(self) -> Vec<Operation> {
+        self.finalize_with_offset(0)
+    }
 }
 
-/// Resolve a JumpTarget, converting Unresolved to Resolved.
-fn resolve_target(target: &JumpTarget, label_positions: &[Option<usize>]) -> JumpTarget {
+/// Resolve a JumpTarget, converting Unresolved to Resolved with an offset added.
+/// This allows labels to be resolved directly to their final addresses when
+/// code blocks are concatenated.
+///
+/// All jump targets are Unresolved when emitted (even backward jumps), so
+/// resolution only happens here in one place.
+fn resolve_target_with_offset(
+    target: &JumpTarget,
+    label_positions: &[Option<usize>],
+    offset: usize,
+) -> JumpTarget {
     match target {
-        JumpTarget::Resolved(addr) => JumpTarget::Resolved(*addr),
+        JumpTarget::Resolved(_) => {
+            panic!("Bug: JumpTarget should be Unresolved before finalize")
+        }
         JumpTarget::Unresolved(Label(id)) => {
-            let addr = label_positions[*id].expect("Label was never bound");
-            JumpTarget::Resolved(addr)
+            let base_addr = label_positions[*id].expect("Label was never bound");
+            JumpTarget::Resolved(base_addr + offset)
         }
     }
 }

--- a/src/compiler/nodes.rs
+++ b/src/compiler/nodes.rs
@@ -37,11 +37,14 @@ impl CodegenContext {
 
     /// Finalize and combine init + body code.
     /// Layout: init_code + GoTo(body_start) + body_code
+    ///
+    /// Body code labels are resolved with an offset, so they point to the correct
+    /// addresses in the final combined program. This eliminates the need for a
+    /// separate jump target adjustment pass.
     pub fn finalize(self) -> Vec<Operation> {
         let init_ops = self.init_emitter.finalize();
-        let body_ops = self.body_emitter.finalize();
 
-        let mut result = Vec::with_capacity(init_ops.len() + 1 + body_ops.len());
+        let mut result = Vec::with_capacity(init_ops.len() + 1);
 
         // Add init code
         result.extend(init_ops);
@@ -50,48 +53,12 @@ impl CodegenContext {
         let body_start = result.len() + 1;
         result.push(Operation::GoTo(JumpTarget::addr(body_start)));
 
-        // Add body code, adjusting all jump targets by the offset
+        // Add body code, resolving labels with offset baked in
         let offset = result.len();
-        for op in body_ops {
-            result.push(adjust_jump_targets(op, offset));
-        }
+        let body_ops = self.body_emitter.finalize_with_offset(offset);
+        result.extend(body_ops);
 
         result
-    }
-}
-
-/// Adjust jump targets in an operation by adding an offset.
-fn adjust_jump_targets(op: Operation, offset: usize) -> Operation {
-    match op {
-        Operation::GoTo(JumpTarget::Resolved(addr)) => {
-            Operation::GoTo(JumpTarget::Resolved(addr + offset))
-        }
-        Operation::GoToIfFalse(JumpTarget::Resolved(addr), reg) => {
-            Operation::GoToIfFalse(JumpTarget::Resolved(addr + offset), reg)
-        }
-        Operation::GoToIfEqualValue(JumpTarget::Resolved(addr), lhs, rhs) => {
-            Operation::GoToIfEqualValue(JumpTarget::Resolved(addr + offset), lhs, rhs)
-        }
-        Operation::PopKey(dest, list, JumpTarget::Resolved(addr)) => {
-            Operation::PopKey(dest, list, JumpTarget::Resolved(addr + offset))
-        }
-        Operation::YieldFromRowBuffer(regs, buffer, JumpTarget::Resolved(addr)) => {
-            Operation::YieldFromRowBuffer(regs, buffer, JumpTarget::Resolved(addr + offset))
-        }
-        Operation::YieldFromGroupTable(regs, table, JumpTarget::Resolved(addr)) => {
-            Operation::YieldFromGroupTable(regs, table, JumpTarget::Resolved(addr + offset))
-        }
-        // Unresolved labels should have been resolved by finalize()
-        Operation::GoTo(JumpTarget::Unresolved(_))
-        | Operation::GoToIfFalse(JumpTarget::Unresolved(_), _)
-        | Operation::GoToIfEqualValue(JumpTarget::Unresolved(_), _, _)
-        | Operation::PopKey(_, _, JumpTarget::Unresolved(_))
-        | Operation::YieldFromRowBuffer(_, _, JumpTarget::Unresolved(_))
-        | Operation::YieldFromGroupTable(_, _, JumpTarget::Unresolved(_)) => {
-            panic!("Unresolved jump target after finalize")
-        }
-        // All other operations pass through unchanged
-        other => other,
     }
 }
 

--- a/src/engine/program.rs
+++ b/src/engine/program.rs
@@ -68,12 +68,29 @@ pub struct AggregateSpec {
     pub input_reg: Option<Reg>, // None for COUNT(*)
 }
 
-// TODO: switch to using {} and named members
-//
-// IMPORTANT: When adding new operations that contain JumpTarget fields,
-// you must also update:
-// 1. compiler/nodes.rs: adjust_jump_targets() - add case to adjust jump targets by offset
-// 2. compiler/emitter.rs: finalize() - add case to resolve unresolved labels
+/// VM operations for the bytecode interpreter.
+///
+/// ## Jump Target Safety
+///
+/// Operations that contain JumpTarget fields have compile-time safety enforcement:
+///
+/// **Label Resolution with Offset:**
+/// - Labels stay `Unresolved` until the final finalization step
+/// - `BytecodeEmitter::finalize_with_offset()` resolves labels with offset baked in
+/// - No separate adjustment pass needed - offsets are applied during resolution
+/// - Exhaustive matching (no catch-all) ensures new operations are handled
+///
+/// **How it works:**
+/// 1. Body emitter creates operations with `Unresolved(Label)`
+/// 2. `CodegenContext::finalize()` calls `body_emitter.finalize_with_offset(offset)`
+/// 3. Labels resolve directly to final addresses: `base_addr + offset`
+/// 4. Any operation not handled stays `Unresolved` and panics at runtime
+///
+/// This prevents bugs where:
+/// - Jump targets are resolved but not adjusted (eliminated - no separate step)
+/// - New operations with JumpTarget are added but not handled (compile error)
+///
+/// TODO: switch to using {} and named members
 #[derive(Clone, Debug)]
 pub enum Operation {
     // Value


### PR DESCRIPTION
## Summary

Implements Phase H (Item 40) from the development roadmap, improving compiler safety by eliminating bugs where jump targets are not properly adjusted during code generation.

## Changes

### 1. Deferred Label Resolution
- **All** labels (forward and backward) stay `Unresolved` until finalization
- Labels resolve directly to final addresses with offset baked in
- No intermediate "resolved but unadjusted" state

### 2. Eliminated Adjustment Pass
- Removed `adjust_jump_targets()` function entirely
- No separate pass needed - resolution happens with offset in one step
- Simpler code flow: emit → finalize with offset → done

### 3. Exhaustive Pattern Matching
- `BytecodeEmitter::finalize_with_offset()` uses exhaustive matching (no catch-all)
- Adding new `Operation` with `JumpTarget` causes compiler error
- Forces conscious decision about how to handle new operations

### 4. Encapsulated Resolution
- `label_positions` is private, only accessible during finalize
- All `emit_*` methods create `Unresolved` targets only
- Panic if `Resolved` target exists before finalize (catches bugs early)

## Key Insight

The crucial improvement was deferring **backward jumps** too. Even when a label is already bound, `emit_goto()` creates `Unresolved(Label)` rather than `Resolved(addr)`. This ensures ALL resolution happens in one place with the offset applied correctly.

## What This Prevents

During ORDER BY implementation, we added `YieldFromRowBuffer` with a `JumpTarget` parameter. The old `adjust_jump_targets()` had a catch-all pattern that silently passed the operation through without adjusting its jump target, causing an infinite loop at runtime.

With this change:
- ✅ Compiler errors if new operations with jump targets aren't handled
- ✅ No way to forget offset adjustment (it's baked into resolution)
- ✅ Clear separation: emit phase creates Unresolved, finalize resolves

## Test Plan

- All 236 tests pass (221 unit + 15 SQL integration)
- Zero compiler warnings
- Verified bytecode correctness for backward/forward jumps
- Tested with COUNT, ORDER BY, GROUP BY (operations with complex jump patterns)

## Files Changed

- `src/compiler/emitter.rs`: Added `finalize_with_offset()`, deferred all resolution
- `src/compiler/nodes.rs`: Removed `adjust_jump_targets()`, simplified `finalize()`
- `src/engine/program.rs`: Updated documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)