### PR TITLE
Implement variable-length B-tree keys (Item 41)

### DIFF
--- a/src/compiler/nodes.rs
+++ b/src/compiler/nodes.rs
@@ -1424,15 +1424,15 @@ mod tests {
             let mut v0 = Vec::new();
             let values = vec![ScalarValue::Integer(1), ScalarValue::Integer(100)];
             ciborium::ser::into_writer(&values, &mut v0).unwrap();
-            c.insert(0, v0);
+            c.insert_u64(0, v0);
             let mut v1 = Vec::new();
             let values = vec![ScalarValue::Integer(2), ScalarValue::Integer(200)];
             ciborium::ser::into_writer(&values, &mut v1).unwrap();
-            c.insert(1, v1);
+            c.insert_u64(1, v1);
             let mut v2 = Vec::new();
             let values = vec![ScalarValue::Integer(3), ScalarValue::Integer(300)];
             ciborium::ser::into_writer(&values, &mut v2).unwrap();
-            c.insert(2, v2);
+            c.insert_u64(2, v2);
         }
 
         // Build plan: Count { Scan { rootpage, 2 columns } }
@@ -1494,11 +1494,11 @@ mod tests {
             let mut v0 = Vec::new();
             let values = vec![ScalarValue::Integer(10), ScalarValue::Integer(20)];
             ciborium::ser::into_writer(&values, &mut v0).unwrap();
-            c.insert(0, v0);
+            c.insert_u64(0, v0);
             let mut v1 = Vec::new();
             let values = vec![ScalarValue::Integer(30), ScalarValue::Integer(40)];
             ciborium::ser::into_writer(&values, &mut v1).unwrap();
-            c.insert(1, v1);
+            c.insert_u64(1, v1);
         }
 
         let plan = LogicalPlan::Scan {

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,14 +1,15 @@
 use crate::compiler;
 use crate::engine::scalarvalue::ScalarValue;
 use crate::engine::Engine;
-use crate::frontend::ast::Statement;
+use crate::frontend::ast::{DataType, Statement};
 use crate::frontend::{parse, ParseError};
 use crate::planner::{self, PlanError};
-use crate::storage::BTree;
+use crate::storage::{encode_integer_key, BTree};
 
 #[derive(Debug)]
 pub enum ExecuteResult {
     CreateTable { table_name: String },
+    CreateIndex { index_name: String },
     DropTable { table_name: String },
     Query(QueryExecution),
 }
@@ -42,6 +43,9 @@ pub enum ExecuteError {
     Plan(PlanError),
     TableAlreadyExists(String),
     TableNotFound(String),
+    IndexAlreadyExists(String),
+    ColumnNotFound { table: String, column: String },
+    ColumnNotInteger { table: String, column: String },
 }
 
 impl std::fmt::Display for ExecuteError {
@@ -54,6 +58,19 @@ impl std::fmt::Display for ExecuteError {
             }
             ExecuteError::TableNotFound(name) => {
                 write!(f, "Table '{}' not found", name)
+            }
+            ExecuteError::IndexAlreadyExists(name) => {
+                write!(f, "Index '{}' already exists", name)
+            }
+            ExecuteError::ColumnNotFound { table, column } => {
+                write!(f, "Column '{}' not found in table '{}'", column, table)
+            }
+            ExecuteError::ColumnNotInteger { table, column } => {
+                write!(
+                    f,
+                    "Column '{}' in table '{}' is not INTEGER (V1: only INTEGER columns supported)",
+                    column, table
+                )
             }
         }
     }
@@ -102,7 +119,108 @@ pub fn execute(sql: &str, btree: &mut BTree) -> Result<ExecuteResult, ExecuteErr
             })
         }
         Statement::CreateIndex(_) => {
-            todo!("CREATE INDEX not yet implemented")
+            let ci = match stmt {
+                Statement::CreateIndex(ci) => ci,
+                _ => unreachable!(),
+            };
+
+            // 1. Resolve table and validate it exists
+            let (table_rootpage, ddl) = btree
+                .lookup_table(&ci.table_name)
+                .ok_or_else(|| ExecuteError::TableNotFound(ci.table_name.clone()))?;
+
+            // 2. Check if index already exists
+            let existing = btree.lookup_indexes_for_table(&ci.table_name);
+            for index in &existing {
+                if index.index_name == ci.index_name {
+                    return Err(ExecuteError::IndexAlreadyExists(ci.index_name.clone()));
+                }
+            }
+
+            // 3. Parse DDL to get column info
+            let parsed_ddl = parse(&ddl).map_err(ExecuteError::Parse)?;
+            let create_table = match parsed_ddl {
+                Statement::CreateTable(ct) => ct,
+                _ => return Err(ExecuteError::Parse(crate::frontend::ParseError::UnexpectedToken(
+                    crate::frontend::parser::Expect::Table,
+                    crate::frontend::lexer::Type::Eof,
+                ))),
+            };
+
+            // 4. Find column and verify it's INTEGER (V1 restriction)
+            let column_def = create_table
+                .columns
+                .iter()
+                .find(|col| col.name == ci.column_name)
+                .ok_or_else(|| ExecuteError::ColumnNotFound {
+                    table: ci.table_name.clone(),
+                    column: ci.column_name.clone(),
+                })?;
+
+            if !matches!(column_def.type_name, Some(DataType::Integer)) {
+                return Err(ExecuteError::ColumnNotInteger {
+                    table: ci.table_name.clone(),
+                    column: ci.column_name.clone(),
+                });
+            }
+
+            let column_idx = create_table
+                .columns
+                .iter()
+                .position(|col| col.name == ci.column_name)
+                .unwrap();
+
+            // 5. Create the index B-tree
+            let index_rootpage = btree.create_tree();
+
+            // 6. Scan table and collect (index_key, primary_key) pairs, then write to index.
+            // We collect first to avoid holding readonly borrow while inserting (readwrite borrow).
+            let entries_to_index: Vec<(u64, i64)> = {
+                let mut table_cursor = btree.open(table_rootpage);
+                let mut tc = table_cursor.open_readonly();
+                tc.first();
+                let mut entries = Vec::new();
+                loop {
+                    match tc.get_entry() {
+                        None => break,
+                        Some(mut reader) => {
+                            let table_key = reader.key();
+                            let values = reader.decode_as_array();
+                            if column_idx < values.len() {
+                                if let ScalarValue::Integer(col_int) = values[column_idx] {
+                                    entries.push((
+                                        encode_integer_key(col_int),
+                                        table_key as i64,
+                                    ));
+                                }
+                            }
+                        }
+                    }
+                    tc.next();
+                }
+                entries
+            };
+
+            for (index_key, pk) in entries_to_index {
+                let index_value = vec![ScalarValue::Integer(pk)];
+                let mut encoded = Vec::new();
+                ciborium::ser::into_writer(&index_value, &mut encoded).unwrap();
+                let mut index_cursor = btree.open(index_rootpage);
+                index_cursor.open_readwrite().insert(index_key, encoded);
+            }
+
+            // 7. Add catalog entry
+            btree.insert_schema_entry(
+                "index",
+                &ci.index_name,
+                &ci.table_name,
+                index_rootpage,
+                sql,
+            );
+
+            Ok(ExecuteResult::CreateIndex {
+                index_name: ci.index_name.clone(),
+            })
         }
         Statement::Select(_)
         | Statement::Insert(_)

--- a/src/db.rs
+++ b/src/db.rs
@@ -4,7 +4,7 @@ use crate::engine::Engine;
 use crate::frontend::ast::{DataType, Statement};
 use crate::frontend::{parse, ParseError};
 use crate::planner::{self, PlanError};
-use crate::storage::{encode_integer_key, BTree};
+use crate::storage::{decode_u64_key, encode_integer_key, BTree};
 
 #[derive(Debug)]
 pub enum ExecuteResult {
@@ -141,10 +141,14 @@ pub fn execute(sql: &str, btree: &mut BTree) -> Result<ExecuteResult, ExecuteErr
             let parsed_ddl = parse(&ddl).map_err(ExecuteError::Parse)?;
             let create_table = match parsed_ddl {
                 Statement::CreateTable(ct) => ct,
-                _ => return Err(ExecuteError::Parse(crate::frontend::ParseError::UnexpectedToken(
-                    crate::frontend::parser::Expect::Table,
-                    crate::frontend::lexer::Type::Eof,
-                ))),
+                _ => {
+                    return Err(ExecuteError::Parse(
+                        crate::frontend::ParseError::UnexpectedToken(
+                            crate::frontend::parser::Expect::Table,
+                            crate::frontend::lexer::Type::Eof,
+                        ),
+                    ))
+                }
             };
 
             // 4. Find column and verify it's INTEGER (V1 restriction)
@@ -175,7 +179,7 @@ pub fn execute(sql: &str, btree: &mut BTree) -> Result<ExecuteResult, ExecuteErr
 
             // 6. Scan table and collect (index_key, primary_key) pairs, then write to index.
             // We collect first to avoid holding readonly borrow while inserting (readwrite borrow).
-            let entries_to_index: Vec<(u64, i64)> = {
+            let entries_to_index: Vec<(Vec<u8>, i64)> = {
                 let mut table_cursor = btree.open(table_rootpage);
                 let mut tc = table_cursor.open_readonly();
                 tc.first();
@@ -184,14 +188,11 @@ pub fn execute(sql: &str, btree: &mut BTree) -> Result<ExecuteResult, ExecuteErr
                     match tc.get_entry() {
                         None => break,
                         Some(mut reader) => {
-                            let table_key = reader.key();
+                            let table_key = decode_u64_key(reader.key());
                             let values = reader.decode_as_array();
                             if column_idx < values.len() {
                                 if let ScalarValue::Integer(col_int) = values[column_idx] {
-                                    entries.push((
-                                        encode_integer_key(col_int),
-                                        table_key as i64,
-                                    ));
+                                    entries.push((encode_integer_key(col_int), table_key as i64));
                                 }
                             }
                         }
@@ -206,17 +207,11 @@ pub fn execute(sql: &str, btree: &mut BTree) -> Result<ExecuteResult, ExecuteErr
                 let mut encoded = Vec::new();
                 ciborium::ser::into_writer(&index_value, &mut encoded).unwrap();
                 let mut index_cursor = btree.open(index_rootpage);
-                index_cursor.open_readwrite().insert(index_key, encoded);
+                index_cursor.open_readwrite().insert(&index_key, encoded);
             }
 
             // 7. Add catalog entry
-            btree.insert_schema_entry(
-                "index",
-                &ci.index_name,
-                &ci.table_name,
-                index_rootpage,
-                sql,
-            );
+            btree.insert_schema_entry("index", &ci.index_name, &ci.table_name, index_rootpage, sql);
 
             Ok(ExecuteResult::CreateIndex {
                 index_name: ci.index_name.clone(),

--- a/src/db.rs
+++ b/src/db.rs
@@ -101,6 +101,9 @@ pub fn execute(sql: &str, btree: &mut BTree) -> Result<ExecuteResult, ExecuteErr
                 table_name: name.clone(),
             })
         }
+        Statement::CreateIndex(_) => {
+            todo!("CREATE INDEX not yet implemented")
+        }
         Statement::Select(_)
         | Statement::Insert(_)
         | Statement::Update(_)

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -592,7 +592,7 @@ impl Engine {
                     program::MoveOperation::Next => cursor.next(),
                     program::MoveOperation::Last => cursor.last(),
                     program::MoveOperation::Find(_) => {
-                        cursor.find(find_key.unwrap());
+                        cursor.find_u64(find_key.unwrap());
                     }
                 }
             }
@@ -621,7 +621,7 @@ impl Engine {
                 let cursor = self.registers.get_mut(cursor_reg).cursor_mut().unwrap();
                 let mut cursor = cursor.open_readonly();
                 let entry = cursor.get_entry().unwrap();
-                let key = entry.key();
+                let key = storage::decode_u64_key(entry.key());
                 drop(cursor);
                 *self.registers.get_mut(dest) =
                     RegisterValue::ScalarValue(ScalarValue::Integer(key as i64));
@@ -645,7 +645,7 @@ impl Engine {
                 // Write to btree
                 let cursor = self.registers.get_mut(cursor_reg).cursor_mut().unwrap();
                 let mut cursor = cursor.open_readwrite();
-                cursor.insert(key, bytes);
+                cursor.insert_u64(key, bytes);
             }
             DeleteCursor(cursor_reg) => {
                 // Delete at current cursor position
@@ -1184,13 +1184,13 @@ mod test {
             let mut v0 = Vec::new();
             let values = vec![ScalarValue::Integer(12345), ScalarValue::Integer(6789)];
             ciborium::ser::into_writer(&values, &mut v0).unwrap();
-            c.insert(0, v0);
+            c.insert_u64(0, v0);
             let mut v1 = Vec::new();
             let values = vec![ScalarValue::Integer(12345)];
             ciborium::ser::into_writer(&values, &mut v1).unwrap();
-            c.insert(1, v1.clone());
-            c.insert(2, v1.clone());
-            c.insert(3, v1);
+            c.insert_u64(1, v1.clone());
+            c.insert_u64(2, v1.clone());
+            c.insert_u64(3, v1);
         }
 
         let r0 = Reg::new(0);
@@ -1232,13 +1232,13 @@ mod test {
             let mut v0 = Vec::new();
             let values = vec![ScalarValue::Integer(12345), ScalarValue::Integer(6789)];
             ciborium::ser::into_writer(&values, &mut v0).unwrap();
-            c.insert(0, v0);
+            c.insert_u64(0, v0);
             let mut v1 = Vec::new();
             let values = vec![ScalarValue::Integer(12345), ScalarValue::Integer(0)];
             ciborium::ser::into_writer(&values, &mut v1).unwrap();
-            c.insert(1, v1.clone());
-            c.insert(2, v1.clone());
-            c.insert(3, v1);
+            c.insert_u64(1, v1.clone());
+            c.insert_u64(2, v1.clone());
+            c.insert_u64(3, v1);
         }
 
         let r0 = Reg::new(0);
@@ -1288,7 +1288,7 @@ mod test {
                 ScalarValue::Integer(30),
             ];
             ciborium::ser::into_writer(&values0, &mut v0).unwrap();
-            c.insert(0, v0);
+            c.insert_u64(0, v0);
             let mut v1 = Vec::new();
             let values1 = vec![
                 ScalarValue::Integer(2),
@@ -1296,7 +1296,7 @@ mod test {
                 ScalarValue::Integer(25),
             ];
             ciborium::ser::into_writer(&values1, &mut v1).unwrap();
-            c.insert(1, v1);
+            c.insert_u64(1, v1);
         }
 
         let r0 = Reg::new(0);
@@ -1371,11 +1371,11 @@ mod test {
             let mut v0 = Vec::new();
             let values = vec![ScalarValue::Integer(100), ScalarValue::Integer(200)];
             ciborium::ser::into_writer(&values, &mut v0).unwrap();
-            c.insert(0, v0);
+            c.insert_u64(0, v0);
             let mut v1 = Vec::new();
             let values = vec![ScalarValue::Integer(300), ScalarValue::Integer(400)];
             ciborium::ser::into_writer(&values, &mut v1).unwrap();
-            c.insert(1, v1);
+            c.insert_u64(1, v1);
         }
 
         let r0 = Reg::new(0);
@@ -1491,15 +1491,15 @@ mod test {
             let mut v1 = Vec::new();
             let values = vec![ScalarValue::Integer(10)];
             ciborium::ser::into_writer(&values, &mut v1).unwrap();
-            c.insert(1, v1);
+            c.insert_u64(1, v1);
             let mut v2 = Vec::new();
             let values = vec![ScalarValue::Integer(20)];
             ciborium::ser::into_writer(&values, &mut v2).unwrap();
-            c.insert(2, v2);
+            c.insert_u64(2, v2);
             let mut v5 = Vec::new();
             let values = vec![ScalarValue::Integer(50)];
             ciborium::ser::into_writer(&values, &mut v5).unwrap();
-            c.insert(5, v5);
+            c.insert_u64(5, v5);
         }
 
         let r_cursor = Reg::new(0);
@@ -1634,15 +1634,15 @@ mod test {
             let mut v10 = Vec::new();
             let values = vec![ScalarValue::Integer(100)];
             ciborium::ser::into_writer(&values, &mut v10).unwrap();
-            c.insert(10, v10);
+            c.insert_u64(10, v10);
             let mut v20 = Vec::new();
             let values = vec![ScalarValue::Integer(200)];
             ciborium::ser::into_writer(&values, &mut v20).unwrap();
-            c.insert(20, v20);
+            c.insert_u64(20, v20);
             let mut v30 = Vec::new();
             let values = vec![ScalarValue::Integer(300)];
             ciborium::ser::into_writer(&values, &mut v30).unwrap();
-            c.insert(30, v30);
+            c.insert_u64(30, v30);
         }
 
         let r_cursor = Reg::new(0);
@@ -1680,15 +1680,15 @@ mod test {
             let mut v1 = Vec::new();
             let values = vec![ScalarValue::Integer(10)];
             ciborium::ser::into_writer(&values, &mut v1).unwrap();
-            c.insert(1, v1);
+            c.insert_u64(1, v1);
             let mut v2 = Vec::new();
             let values = vec![ScalarValue::Integer(20)];
             ciborium::ser::into_writer(&values, &mut v2).unwrap();
-            c.insert(2, v2);
+            c.insert_u64(2, v2);
             let mut v3 = Vec::new();
             let values = vec![ScalarValue::Integer(30)];
             ciborium::ser::into_writer(&values, &mut v3).unwrap();
-            c.insert(3, v3);
+            c.insert_u64(3, v3);
         }
 
         let r_cursor = Reg::new(0);
@@ -1867,15 +1867,15 @@ mod test {
             let mut v10 = Vec::new();
             let values = vec![ScalarValue::Integer(30)];
             ciborium::ser::into_writer(&values, &mut v10).unwrap();
-            c.insert(10, v10);
+            c.insert_u64(10, v10);
             let mut v20 = Vec::new();
             let values = vec![ScalarValue::Integer(10)];
             ciborium::ser::into_writer(&values, &mut v20).unwrap();
-            c.insert(20, v20);
+            c.insert_u64(20, v20);
             let mut v30 = Vec::new();
             let values = vec![ScalarValue::Integer(20)];
             ciborium::ser::into_writer(&values, &mut v30).unwrap();
-            c.insert(30, v30);
+            c.insert_u64(30, v30);
         }
 
         let r_buffer = Reg::new(0);
@@ -1952,7 +1952,7 @@ mod test {
                 ScalarValue::Integer(25),
             ];
             ciborium::ser::into_writer(&values1, &mut v1).unwrap();
-            c.insert(1, v1);
+            c.insert_u64(1, v1);
             let mut v2 = Vec::new();
             let values2 = vec![
                 ScalarValue::Integer(2),
@@ -1960,7 +1960,7 @@ mod test {
                 ScalarValue::Integer(30),
             ];
             ciborium::ser::into_writer(&values2, &mut v2).unwrap();
-            c.insert(2, v2);
+            c.insert_u64(2, v2);
             let mut v3 = Vec::new();
             let values3 = vec![
                 ScalarValue::Integer(3),
@@ -1968,7 +1968,7 @@ mod test {
                 ScalarValue::Integer(28),
             ];
             ciborium::ser::into_writer(&values3, &mut v3).unwrap();
-            c.insert(3, v3);
+            c.insert_u64(3, v3);
         }
 
         // Exact bytecode from debug.txt

--- a/src/frontend/ast.rs
+++ b/src/frontend/ast.rs
@@ -2,10 +2,18 @@
 pub enum Statement {
     Select(SelectStatement),
     CreateTable(CreateTableStatement),
+    CreateIndex(CreateIndexStatement),
     Insert(InsertStatement),
     Update(UpdateStatement),
     Delete(DeleteStatement),
     Drop(DropTableStatement),
+}
+
+#[derive(Debug)]
+pub struct CreateIndexStatement {
+    pub index_name: String,
+    pub table_name: String,
+    pub column_name: String,
 }
 
 #[derive(Debug)]

--- a/src/frontend/lexer.rs
+++ b/src/frontend/lexer.rs
@@ -82,6 +82,7 @@ pub enum Type {
     Join,
     On,
     Inner,
+    Index,
 
     #[allow(dead_code)]
     Error(Error),
@@ -531,6 +532,7 @@ impl<'a> Lexer<'a> {
                         _ => Type::Identifier(ident.to_owned()),
                     },
                     Some('n') => match_reserved(ident, "inner", Type::Inner),
+                    Some('d') => match_reserved(ident, "index", Type::Index),
                     _ => Type::Identifier(ident.to_owned()),
                 },
                 Some('s') => match_reserved(ident, "is", Type::Is),
@@ -765,6 +767,20 @@ mod test {
             .iter()
             .any(|t| matches!(t.tipe(), super::Type::FloatingPointNumber(4.5)));
         assert!(has_float_4_5, "Should have FloatingPointNumber(4.5)");
+    }
+
+    #[test]
+    fn test_index_keyword() {
+        let tokens = lex("CREATE INDEX idx_age ON users(age)");
+        let types: Vec<super::Type> = tokens.iter().map(|t| t.tipe()).collect();
+        assert!(matches!(types[0], super::Type::Create));
+        assert!(matches!(types[1], super::Type::Index));
+        assert!(matches!(types[2], super::Type::Identifier(_)));
+        assert!(matches!(types[3], super::Type::On));
+        assert!(matches!(types[4], super::Type::Identifier(_)));
+        assert!(matches!(types[5], super::Type::LeftParen));
+        assert!(matches!(types[6], super::Type::Identifier(_)));
+        assert!(matches!(types[7], super::Type::RightParen));
     }
 
     #[test]

--- a/src/frontend/parser.rs
+++ b/src/frontend/parser.rs
@@ -346,11 +346,6 @@ impl Parser {
         Ok(ast::DropTableStatement { table_name })
     }
 
-    fn parse_create_table_statement(&mut self) -> ParseResult<ast::CreateTableStatement> {
-        self.input.expect(Expect::Create)?;
-        self.parse_create_table_statement_after_create()
-    }
-
     fn parse_create_table_statement_after_create(&mut self) -> ParseResult<ast::CreateTableStatement> {
         self.input.expect(Expect::Table)?;
         let table_name = self.parse_identifier()?;

--- a/src/frontend/parser.rs
+++ b/src/frontend/parser.rs
@@ -346,7 +346,9 @@ impl Parser {
         Ok(ast::DropTableStatement { table_name })
     }
 
-    fn parse_create_table_statement_after_create(&mut self) -> ParseResult<ast::CreateTableStatement> {
+    fn parse_create_table_statement_after_create(
+        &mut self,
+    ) -> ParseResult<ast::CreateTableStatement> {
         self.input.expect(Expect::Table)?;
         let table_name = self.parse_identifier()?;
         self.input.expect(Expect::LeftParen)?;

--- a/src/frontend/parser.rs
+++ b/src/frontend/parser.rs
@@ -71,6 +71,10 @@ impl ParserInput {
                 self.advance();
                 Ok(())
             }
+            (Expect::Index, lexer::Type::Index) => {
+                self.advance();
+                Ok(())
+            }
             (Expect::Insert, lexer::Type::Insert) => {
                 self.advance();
                 Ok(())
@@ -148,6 +152,7 @@ pub enum Expect {
     Select,
     Create,
     Table,
+    Index,
     Insert,
     Into,
     Values,
@@ -203,9 +208,18 @@ impl Parser {
     pub(crate) fn parse_statement(&mut self) -> ParseResult<ast::Statement> {
         match self.input.peek() {
             lexer::Type::Select => Ok(ast::Statement::Select(self.parse_select_statement()?)),
-            lexer::Type::Create => Ok(ast::Statement::CreateTable(
-                self.parse_create_table_statement()?,
-            )),
+            lexer::Type::Create => {
+                self.input.advance(); // consume CREATE
+                match self.input.peek() {
+                    lexer::Type::Table => Ok(ast::Statement::CreateTable(
+                        self.parse_create_table_statement_after_create()?,
+                    )),
+                    lexer::Type::Index => Ok(ast::Statement::CreateIndex(
+                        self.parse_create_index_statement()?,
+                    )),
+                    t => Err(ParseError::UnexpectedToken(Expect::Table, t)),
+                }
+            }
             lexer::Type::Insert => Ok(ast::Statement::Insert(self.parse_insert_statement()?)),
             lexer::Type::Update => Ok(ast::Statement::Update(self.parse_update_statement()?)),
             lexer::Type::Delete => Ok(ast::Statement::Delete(self.parse_delete_statement()?)),
@@ -334,6 +348,10 @@ impl Parser {
 
     fn parse_create_table_statement(&mut self) -> ParseResult<ast::CreateTableStatement> {
         self.input.expect(Expect::Create)?;
+        self.parse_create_table_statement_after_create()
+    }
+
+    fn parse_create_table_statement_after_create(&mut self) -> ParseResult<ast::CreateTableStatement> {
         self.input.expect(Expect::Table)?;
         let table_name = self.parse_identifier()?;
         self.input.expect(Expect::LeftParen)?;
@@ -350,6 +368,23 @@ impl Parser {
         Ok(ast::CreateTableStatement {
             table_name,
             columns,
+        })
+    }
+
+    fn parse_create_index_statement(&mut self) -> ParseResult<ast::CreateIndexStatement> {
+        // CREATE INDEX idx_name ON table_name(column_name)
+        // (CREATE already consumed by caller)
+        self.input.expect(Expect::Index)?;
+        let index_name = self.parse_identifier()?;
+        self.input.expect(Expect::On)?;
+        let table_name = self.parse_identifier()?;
+        self.input.expect(Expect::LeftParen)?;
+        let column_name = self.parse_identifier()?;
+        self.input.expect(Expect::RightParen)?;
+        Ok(ast::CreateIndexStatement {
+            index_name,
+            table_name,
+            column_name,
         })
     }
 
@@ -1181,6 +1216,20 @@ mod test {
                 assert!(matches!(select.columns[1], ast::ColumnExpression::Wildcard));
             }
             _ => panic!("Expected Select statement"),
+        }
+    }
+
+    #[test]
+    fn test_parse_create_index() {
+        let sql = "CREATE INDEX idx_age ON users(age)";
+        let stmt = parse(sql).unwrap();
+        match stmt {
+            ast::Statement::CreateIndex(ci) => {
+                assert_eq!(ci.index_name, "idx_age");
+                assert_eq!(ci.table_name, "users");
+                assert_eq!(ci.column_name, "age");
+            }
+            _ => panic!("Expected CreateIndex statement"),
         }
     }
 

--- a/src/planner.rs
+++ b/src/planner.rs
@@ -267,11 +267,12 @@ pub fn plan(statement: Statement, btree: &BTree) -> Result<LogicalPlan, PlanErro
                 plan_select_with_joins(select, btree)
             }
         }
-        Statement::CreateTable(_) => Err(PlanError::UnsupportedStatement),
+        Statement::CreateTable(_) | Statement::CreateIndex(_) | Statement::Drop(_) => {
+            Err(PlanError::UnsupportedStatement)
+        }
         Statement::Insert(insert) => plan_insert(insert, btree),
         Statement::Update(update) => plan_update(update, btree),
         Statement::Delete(delete) => plan_delete(delete, btree),
-        Statement::Drop(_) => Err(PlanError::UnsupportedStatement),
     }
 }
 

--- a/src/planner.rs
+++ b/src/planner.rs
@@ -2648,7 +2648,7 @@ mod tests {
             let mut c = cursor.open_readwrite();
             let mut buf = Vec::new();
             ciborium::ser::into_writer(&values, &mut buf).unwrap();
-            c.insert(1, buf); // key 1 (catalog row 0 is self-referencing db_schema)
+            c.insert_u64(1, buf); // key 1 (catalog row 0 is self-referencing db_schema)
         }
 
         // Create employees table (id, name, dept_id)
@@ -2667,7 +2667,7 @@ mod tests {
             let mut c = cursor.open_readwrite();
             let mut buf = Vec::new();
             ciborium::ser::into_writer(&values, &mut buf).unwrap();
-            c.insert(2, buf); // key 2
+            c.insert_u64(2, buf); // key 2
         }
 
         // Plan: "SELECT e.name, d.name FROM employees AS e JOIN departments AS d ON e.dept_id = d.id"

--- a/src/repl/modes/btree.rs
+++ b/src/repl/modes/btree.rs
@@ -153,7 +153,7 @@ impl Mode for BTreeMode {
                     Err(_) => return CommandResult::Error("Invalid key (must be u64)".to_string()),
                 };
                 self.with_cursor(|cursor| {
-                    cursor.handle.open_readonly().find(key);
+                    cursor.handle.open_readonly().find_u64(key);
                     CommandResult::Ok
                 })
             }
@@ -190,7 +190,7 @@ impl Mode for BTreeMode {
                     cursor
                         .handle
                         .open_readwrite()
-                        .insert(key, value.into_bytes());
+                        .insert_u64(key, value.into_bytes());
                     CommandResult::Message(format!("Inserted key {}", key))
                 })
             }
@@ -222,7 +222,7 @@ impl Mode for BTreeMode {
                         let key =
                             rng.sample(rand::distributions::Uniform::new(1 << 10, 1u64 << 32));
 
-                        cursor.handle.open_readwrite().insert(key, bytes);
+                        cursor.handle.open_readwrite().insert_u64(key, bytes);
                     }
                     CommandResult::Message(format!(
                         "Inserted {} items with random size up to {}",
@@ -389,12 +389,17 @@ fn print_value(entry: Option<CellReader<'_>>) -> ControlFlow<()> {
             ControlFlow::Break(())
         }
         Some(mut entry) => {
-            let key = entry.key();
+            let key_hex = entry
+                .key()
+                .iter()
+                .map(|b| format!("{:02x}", b))
+                .collect::<Vec<_>>()
+                .join("");
             let mut value_buf = Vec::new();
             let value_size = entry.read_to_end(&mut value_buf);
 
             if value_size.is_err() {
-                println!("Entry: key={}, value=<unable to read value>", key);
+                println!("Entry: key={}, value=<unable to read value>", key_hex);
                 return ControlFlow::Continue(());
             }
 
@@ -408,11 +413,11 @@ fn print_value(entry: Option<CellReader<'_>>) -> ControlFlow<()> {
             {
                 let display = format!("{:?}", scalar_values);
                 if display.len() < 80 {
-                    println!("Entry: key={}, len={} value={}", key, len, display);
+                    println!("Entry: key={}, len={} value={}", key_hex, len, display);
                 } else {
                     println!(
                         "Entry: key={}, len={} value=<redacted {} items>",
-                        key,
+                        key_hex,
                         len,
                         scalar_values.len()
                     );
@@ -423,9 +428,9 @@ fn print_value(entry: Option<CellReader<'_>>) -> ControlFlow<()> {
             // Try UTF-8 decoding
             if let Ok(str_value) = String::from_utf8(value_buf.clone()) {
                 if str_value.len() < 80 {
-                    println!("Entry: key={}, len={} value={}", key, len, str_value);
+                    println!("Entry: key={}, len={} value={}", key_hex, len, str_value);
                 } else {
-                    println!("Entry: key={}, len={} value=<redacted text>", key, len);
+                    println!("Entry: key={}, len={} value=<redacted text>", key_hex, len);
                 }
                 return ControlFlow::Continue(());
             }
@@ -440,7 +445,7 @@ fn print_value(entry: Option<CellReader<'_>>) -> ControlFlow<()> {
             let suffix = if value_buf.len() > 16 { "..." } else { "" };
             println!(
                 "Entry: key={}, len={} value=<binary: {}{}>",
-                key, len, hex_preview, suffix
+                key_hex, len, hex_preview, suffix
             );
 
             ControlFlow::Continue(())

--- a/src/repl/modes/sql.rs
+++ b/src/repl/modes/sql.rs
@@ -37,6 +37,9 @@ impl Mode for SqlMode {
             Ok(ExecuteResult::CreateTable { table_name }) => {
                 CommandResult::Message(format!("Table '{}' created", table_name))
             }
+            Ok(ExecuteResult::CreateIndex { index_name }) => {
+                CommandResult::Message(format!("Index '{}' created", index_name))
+            }
             Ok(ExecuteResult::DropTable { table_name }) => {
                 CommandResult::Message(format!("Table '{}' dropped", table_name))
             }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -11,6 +11,9 @@ mod btree;
 mod btree_graph;
 mod btree_verify;
 
+pub use btree::encode_integer_key;
+pub use btree::decode_integer_key;
+pub use btree::IndexInfo;
 pub use btree::BTree;
 pub use btree::CursorHandle;
 pub use cell_reader::CellReader;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -11,9 +11,11 @@ mod btree;
 mod btree_graph;
 mod btree_verify;
 
-pub use btree::encode_integer_key;
 pub use btree::decode_integer_key;
-pub use btree::IndexInfo;
+pub use btree::decode_u64_key;
+pub use btree::encode_integer_key;
+pub use btree::encode_u64_key;
 pub use btree::BTree;
 pub use btree::CursorHandle;
+pub use btree::IndexInfo;
 pub use cell_reader::CellReader;

--- a/src/storage/btree.rs
+++ b/src/storage/btree.rs
@@ -45,6 +45,14 @@ pub struct CursorState {
 
 impl CursorState {}
 
+/// Metadata for a single index from the catalog
+#[derive(Debug, Clone)]
+pub struct IndexInfo {
+    pub index_name: String,
+    pub column_name: String,
+    pub rootpage: u32,
+}
+
 #[derive(Debug, Clone)]
 pub struct CursorHandle {
     pager: Arc<RefCell<Pager>>,
@@ -812,6 +820,50 @@ impl BTree {
         }
     }
 
+    /// Look up all indexes for a table by scanning db_schema.
+    pub fn lookup_indexes_for_table(&self, table_name: &str) -> Vec<IndexInfo> {
+        let schema_root = match self.schema_root_page() {
+            Some(root) => root,
+            None => return vec![],
+        };
+
+        let mut indexes = Vec::new();
+        let mut cursor = self.open(schema_root);
+        let mut c = cursor.open_readonly();
+        c.first();
+
+        loop {
+            let entry = c.get_entry();
+            match entry {
+                None => break,
+                Some(mut reader) => {
+                    let values = reader.decode_as_array();
+                    // Row format: [type, name, tbl_name, rootpage, sql]
+                    if values.len() >= 5 {
+                        let obj_type = values[0].as_str().unwrap_or("");
+                        let tbl_name = values[2].as_str().unwrap_or("");
+
+                        if obj_type == "index" && tbl_name == table_name {
+                            let name = values[1].as_str().unwrap_or("").to_string();
+                            let rootpage = values[3].as_u64().unwrap() as u32;
+                            let sql = values[4].as_str().unwrap_or("");
+                            let column_name = extract_column_from_index_sql(sql);
+
+                            indexes.push(IndexInfo {
+                                index_name: name,
+                                column_name,
+                                rootpage,
+                            });
+                        }
+                    }
+                }
+            }
+            c.next();
+        }
+
+        indexes
+    }
+
     /// Delete a schema entry (table) from the catalog by table name.
     /// Returns true if the table was found and deleted, false if not found.
     pub fn delete_schema_entry(&mut self, table_name: &str) -> bool {
@@ -992,6 +1044,17 @@ impl Display for BTree {
 
         Ok(())
     }
+}
+
+/// Extract column name from a CREATE INDEX SQL string.
+/// "CREATE INDEX idx ON table(col)" → "col"
+fn extract_column_from_index_sql(sql: &str) -> String {
+    if let Some(start) = sql.find('(') {
+        if let Some(end) = sql[start..].find(')') {
+            return sql[start + 1..start + end].trim().to_string();
+        }
+    }
+    String::new()
 }
 
 #[cfg(test)]
@@ -1299,6 +1362,45 @@ mod test {
 
         let result = btree.lookup_table("nonexistent");
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_lookup_indexes_empty() {
+        let test = TestDb::default();
+        let btree = test.btree;
+
+        let indexes = btree.lookup_indexes_for_table("users");
+        assert_eq!(indexes.len(), 0);
+    }
+
+    #[test]
+    fn test_lookup_indexes_for_table() {
+        let test = TestDb::default();
+        let mut btree = test.btree;
+
+        // Insert a table and an index entry
+        let table_root = btree.create_tree();
+        btree.insert_schema_entry(
+            "table",
+            "users",
+            "users",
+            table_root,
+            "CREATE TABLE users (id INTEGER, name TEXT, age INTEGER)",
+        );
+        let index_root = btree.create_tree();
+        btree.insert_schema_entry(
+            "index",
+            "idx_age",
+            "users",
+            index_root,
+            "CREATE INDEX idx_age ON users(age)",
+        );
+
+        let indexes = btree.lookup_indexes_for_table("users");
+        assert_eq!(indexes.len(), 1);
+        assert_eq!(indexes[0].index_name, "idx_age");
+        assert_eq!(indexes[0].column_name, "age");
+        assert_eq!(indexes[0].rootpage, index_root);
     }
 
     #[test]

--- a/src/storage/btree.rs
+++ b/src/storage/btree.rs
@@ -1046,6 +1046,26 @@ impl Display for BTree {
     }
 }
 
+/// Encode an i64 integer column value to a u64 B-tree key, preserving sort order.
+///
+/// Flips the sign bit so that negative numbers sort before positive numbers
+/// in unsigned key comparison, matching SQL sort order for integers.
+///
+/// Examples:
+///   i64::MIN → 0x0000_0000_0000_0000
+///        -1  → 0x7FFF_FFFF_FFFF_FFFF
+///         0  → 0x8000_0000_0000_0000
+///         1  → 0x8000_0000_0000_0001
+///   i64::MAX → 0xFFFF_FFFF_FFFF_FFFF
+pub fn encode_integer_key(i: i64) -> u64 {
+    (i as u64) ^ 0x8000_0000_0000_0000
+}
+
+/// Decode a u64 index key back to the original i64 column value.
+pub fn decode_integer_key(key: u64) -> i64 {
+    (key ^ 0x8000_0000_0000_0000) as i64
+}
+
 /// Extract column name from a CREATE INDEX SQL string.
 /// "CREATE INDEX idx ON table(col)" → "col"
 fn extract_column_from_index_sql(sql: &str) -> String {
@@ -1362,6 +1382,27 @@ mod test {
 
         let result = btree.lookup_table("nonexistent");
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_integer_key_encoding_order() {
+        use super::{decode_integer_key, encode_integer_key};
+        let values = [-100i64, -1, 0, 1, 100];
+        let encoded: Vec<u64> = values.iter().map(|&v| encode_integer_key(v)).collect();
+
+        // Encoded keys maintain sort order
+        for i in 1..encoded.len() {
+            assert!(
+                encoded[i - 1] < encoded[i],
+                "Keys not ordered: {:?}",
+                values
+            );
+        }
+
+        // Round-trip decode
+        for (i, &v) in values.iter().enumerate() {
+            assert_eq!(decode_integer_key(encoded[i]), v);
+        }
     }
 
     #[test]

--- a/src/storage/btree.rs
+++ b/src/storage/btree.rs
@@ -31,7 +31,7 @@ enum CursorPosition {
     },
 
     /// Position was invalidated by a mutation — lazy seek on next use
-    RequiresSeek { saved_key: u64 },
+    RequiresSeek { saved_key: Vec<u8> },
 
     /// Iterated past the last key
     AtEnd,
@@ -101,7 +101,7 @@ impl<'a, PagerRef> Cursor<'a, PagerRef>
 where
     PagerRef: DerefMut<Target = Pager>,
 {
-    pub fn insert(&mut self, key: u64, value: Value) {
+    pub fn insert(&mut self, key: &[u8], value: Value) {
         assert!(value.len() > 0);
 
         // Save current cursor key if positioned, for RequiresSeek after insert
@@ -127,7 +127,7 @@ where
             (value, None)
         };
 
-        let cell = Cell::new(key, first_part, continuation);
+        let cell = Cell::new(key.to_vec(), first_part, continuation);
 
         // we maintain a stack of the nodes we decended through in case of needing to split them.
         // Starting at the root, we search to find:
@@ -140,7 +140,7 @@ where
         loop {
             let top_page_idx = *stack.last().unwrap();
             let mut top_page: NodePage = self.pager.get_and_decode(top_page_idx);
-            match top_page.search(&key) {
+            match top_page.search(key) {
                 SearchResult::Found(insertion_index) => {
                     // We found the index in the node where an existing value for this key exists
                     // we need to replace it with our value
@@ -171,6 +171,10 @@ where
         if let Some(saved_key) = saved_cursor_key {
             self.cursor_state.position = CursorPosition::RequiresSeek { saved_key };
         }
+    }
+
+    pub fn insert_u64(&mut self, key: u64, value: Value) {
+        self.insert(&encode_u64_key(key), value)
     }
 
     /// Updates a page with new content
@@ -320,7 +324,7 @@ where
 
     /// Delete a key from the B-tree.
     /// If the key exists, it is removed. If not, this is a no-op.
-    pub fn delete(&mut self, key: u64) {
+    pub fn delete(&mut self, key: &[u8]) {
         // Use find to position the cursor on the target leaf
         let found = self.find(key);
 
@@ -331,6 +335,10 @@ where
 
         // Delete at the current cursor position
         self.delete_current();
+    }
+
+    pub fn delete_u64(&mut self, key: u64) {
+        self.delete(&encode_u64_key(key))
     }
 }
 
@@ -343,8 +351,12 @@ where
     /// If the cursor is in RequiresSeek state, performs a find() to reposition.
     /// Returns true if the saved key was found, false if positioned at insertion point.
     fn ensure_positioned(&mut self) -> bool {
-        if let CursorPosition::RequiresSeek { saved_key } = self.cursor_state.position {
-            let found = self.find(saved_key);
+        let saved_key = match &self.cursor_state.position {
+            CursorPosition::RequiresSeek { saved_key } => Some(saved_key.clone()),
+            _ => None,
+        };
+        if let Some(key) = saved_key {
+            let found = self.find(&key);
             // find() sets position to Valid
             // - If found=true: positioned at the saved key
             // - If found=false: positioned at insertion point (successor of saved key)
@@ -432,14 +444,14 @@ where
     /// Move the cursor to point at the row in the btree identified by the given key
     /// Returns true if the key was found, false if not found.
     /// When false, the cursor is positioned where the key would be inserted.
-    pub fn find(&mut self, key: u64) -> bool {
+    pub fn find(&mut self, key: &[u8]) -> bool {
         let mut page_idx = self.cursor_state.root_page;
         let mut stack = Vec::new();
 
         loop {
             let page: NodePage = self.pager.get_and_decode(page_idx);
 
-            match page.search(&key) {
+            match page.search(key) {
                 SearchResult::Found(index) => {
                     self.cursor_state.position = CursorPosition::Valid {
                         stack,
@@ -463,11 +475,15 @@ where
         }
     }
 
+    pub fn find_u64(&mut self, key: u64) -> bool {
+        self.find(&encode_u64_key(key))
+    }
+
     #[allow(dead_code)]
     fn row_key(&mut self) -> Option<u64> {
         let cell = self.get_entry()?;
 
-        Some(cell.key())
+        Some(decode_u64_key(cell.key()))
     }
 
     pub fn get_entry<'b>(&'b mut self) -> Option<CellReader<'b>> {
@@ -755,7 +771,7 @@ impl BTree {
         // Find the maximum key by scanning backwards from the last entry
         c.last();
         if let Some(entry) = c.get_entry() {
-            entry.key() + 1
+            decode_u64_key(entry.key()) + 1
         } else {
             0
         }
@@ -788,7 +804,7 @@ impl BTree {
         let mut row = Vec::new();
         ciborium::ser::into_writer(&row_values, &mut row).unwrap();
         let mut cursor = self.open(schema_root);
-        cursor.open_readwrite().insert(key, row);
+        cursor.open_readwrite().insert_u64(key, row);
     }
 
     /// Look up a table's root page and DDL by scanning db_schema for a matching name.
@@ -943,8 +959,13 @@ impl BTree {
                             let value = cell.value();
                             let continuation = cell.continuation();
 
+                            let key_hex = key
+                                .iter()
+                                .map(|b| format!("{:02x}", b))
+                                .collect::<Vec<_>>()
+                                .join(" ");
                             println!("  {}:", format!("Cell {}", i).bright_blue());
-                            println!("    {}={}", "key".cyan(), key);
+                            println!("    {}={}", "key".cyan(), key_hex);
                             println!("    {}={}", "value_len".cyan(), value.len());
 
                             if let Some(cont_page) = continuation {
@@ -985,11 +1006,16 @@ impl BTree {
                         let child = interior.get_child_page_by_index(i);
                         if i > 0 {
                             let key = interior.get_key_by_index(i - 1);
+                            let key_hex = key
+                                .iter()
+                                .map(|b| format!("{:02x}", b))
+                                .collect::<Vec<_>>()
+                                .join(" ");
                             println!(
                                 "  {}: {}={}, {}={}",
                                 format!("Edge {}", i).bright_blue(),
                                 "key".cyan(),
-                                key,
+                                key_hex,
                                 "child_page".cyan(),
                                 child
                             );
@@ -1046,24 +1072,36 @@ impl Display for BTree {
     }
 }
 
-/// Encode an i64 integer column value to a u64 B-tree key, preserving sort order.
+/// Encode an i64 integer column value to a variable-length B-tree key, preserving sort order.
 ///
 /// Flips the sign bit so that negative numbers sort before positive numbers
-/// in unsigned key comparison, matching SQL sort order for integers.
+/// in big-endian byte comparison, matching SQL sort order for integers.
 ///
 /// Examples:
-///   i64::MIN → 0x0000_0000_0000_0000
-///        -1  → 0x7FFF_FFFF_FFFF_FFFF
-///         0  → 0x8000_0000_0000_0000
-///         1  → 0x8000_0000_0000_0001
-///   i64::MAX → 0xFFFF_FFFF_FFFF_FFFF
-pub fn encode_integer_key(i: i64) -> u64 {
-    (i as u64) ^ 0x8000_0000_0000_0000
+///   i64::MIN → [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
+///        -1  → [0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]
+///         0  → [0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
+///         1  → [0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01]
+///   i64::MAX → [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]
+pub fn encode_integer_key(i: i64) -> Vec<u8> {
+    let encoded = (i as u64) ^ 0x8000_0000_0000_0000;
+    encoded.to_be_bytes().to_vec()
 }
 
-/// Decode a u64 index key back to the original i64 column value.
-pub fn decode_integer_key(key: u64) -> i64 {
-    (key ^ 0x8000_0000_0000_0000) as i64
+/// Decode a variable-length index key back to the original i64 column value.
+pub fn decode_integer_key(bytes: &[u8]) -> i64 {
+    let val = u64::from_be_bytes(bytes.try_into().unwrap());
+    (val ^ 0x8000_0000_0000_0000) as i64
+}
+
+/// Encode a u64 row key as big-endian bytes, preserving sort order.
+pub fn encode_u64_key(key: u64) -> Vec<u8> {
+    key.to_be_bytes().to_vec()
+}
+
+/// Decode a big-endian byte key back to u64.
+pub fn decode_u64_key(bytes: &[u8]) -> u64 {
+    u64::from_be_bytes(bytes.try_into().unwrap())
 }
 
 /// Extract column name from a CREATE INDEX SQL string.
@@ -1132,7 +1170,7 @@ mod test {
             let mut cursor_handle = btree.open(root);
             let mut cursor = cursor_handle.open_readwrite();
 
-            cursor.insert(42, vec![42, 255, 64]);
+            cursor.insert_u64(42, vec![42, 255, 64]);
         }
 
         // Test we can read out the new value
@@ -1162,7 +1200,7 @@ mod test {
 
             for i in 1..10u64 {
                 let value = i.to_be_bytes().to_vec();
-                cursor.insert(i, value);
+                cursor.insert_u64(i, value);
             }
         }
 
@@ -1198,7 +1236,7 @@ mod test {
 
             for i in 1..10u64 {
                 let value = i.to_be_bytes().to_vec();
-                cursor.insert(i, value);
+                cursor.insert_u64(i, value);
             }
         }
 
@@ -1207,7 +1245,7 @@ mod test {
             let mut cursor_handle = btree.open(root);
             let mut cursor = cursor_handle.open_readonly();
 
-            cursor.find(7);
+            cursor.find_u64(7);
 
             for i in 7..10u64 {
                 let mut buf = [0; 8];
@@ -1232,10 +1270,10 @@ mod test {
 
         let long_string = |s: &str, num| s.repeat(num).into_bytes();
 
-        cursor.insert(1, long_string("AA", 263));
-        cursor.insert(10, long_string("BBBB", 900));
+        cursor.insert_u64(1, long_string("AA", 263));
+        cursor.insert_u64(10, long_string("BBBB", 900));
         cursor.debug("");
-        cursor.insert(11, long_string("C", 1));
+        cursor.insert_u64(11, long_string("C", 1));
 
         cursor.first();
         cursor.debug("");
@@ -1275,7 +1313,7 @@ mod test {
             let value = v.to_string().repeat(len).as_bytes().to_vec();
 
             rust_btree.insert(k, value.clone());
-            cursor.insert(k, value);
+            cursor.insert_u64(k, value);
         }
 
         cursor.verify().unwrap();
@@ -1388,9 +1426,9 @@ mod test {
     fn test_integer_key_encoding_order() {
         use super::{decode_integer_key, encode_integer_key};
         let values = [-100i64, -1, 0, 1, 100];
-        let encoded: Vec<u64> = values.iter().map(|&v| encode_integer_key(v)).collect();
+        let encoded: Vec<Vec<u8>> = values.iter().map(|&v| encode_integer_key(v)).collect();
 
-        // Encoded keys maintain sort order
+        // Encoded keys maintain sort order (Vec<u8> compares lexicographically)
         for i in 1..encoded.len() {
             assert!(
                 encoded[i - 1] < encoded[i],
@@ -1401,7 +1439,7 @@ mod test {
 
         // Round-trip decode
         for (i, &v) in values.iter().enumerate() {
-            assert_eq!(decode_integer_key(encoded[i]), v);
+            assert_eq!(decode_integer_key(&encoded[i]), v);
         }
     }
 
@@ -1611,7 +1649,7 @@ mod test {
             let mut c = cursor.open_readwrite();
             for i in 0..100u64 {
                 let value = format!("[{}, \"row_{}\"]", i, i);
-                c.insert(i, value.into_bytes());
+                c.insert_u64(i, value.into_bytes());
             }
         }
 
@@ -1659,21 +1697,21 @@ mod test {
         {
             let mut cursor_handle = btree.open(root);
             let mut cursor = cursor_handle.open_readwrite();
-            cursor.insert(1, b"first".to_vec());
+            cursor.insert_u64(1, b"first".to_vec());
         }
 
         // Insert key=1 again with value "second"
         {
             let mut cursor_handle = btree.open(root);
             let mut cursor = cursor_handle.open_readwrite();
-            cursor.insert(1, b"second".to_vec());
+            cursor.insert_u64(1, b"second".to_vec());
         }
 
         // Read back and verify it's "second"
         {
             let mut cursor_handle = btree.open(root);
             let mut cursor = cursor_handle.open_readonly();
-            cursor.find(1);
+            cursor.find_u64(1);
             let mut buf = vec![];
             cursor
                 .get_entry()
@@ -1695,16 +1733,16 @@ mod test {
         {
             let mut cursor_handle = btree.open(root);
             let mut cursor = cursor_handle.open_readwrite();
-            cursor.insert(1, b"one".to_vec());
-            cursor.insert(3, b"three".to_vec());
-            cursor.insert(5, b"five".to_vec());
+            cursor.insert_u64(1, b"one".to_vec());
+            cursor.insert_u64(3, b"three".to_vec());
+            cursor.insert_u64(5, b"five".to_vec());
         }
 
         // Try to find key 2 (doesn't exist)
         {
             let mut cursor_handle = btree.open(root);
             let mut cursor = cursor_handle.open_readonly();
-            cursor.find(2);
+            cursor.find_u64(2);
             // After find() for non-existent key, cursor should be positioned
             // but get_entry() should return None (or positioned at next key)
             // Current implementation positions at the spot where it would be inserted
@@ -1724,7 +1762,7 @@ mod test {
             let mut cursor_handle = btree.open(root);
             let mut cursor = cursor_handle.open_readwrite();
             for i in 0..10u64 {
-                cursor.insert(i, i.to_be_bytes().to_vec());
+                cursor.insert_u64(i, i.to_be_bytes().to_vec());
             }
         }
 
@@ -1734,7 +1772,7 @@ mod test {
             let mut cursor = cursor_handle.open_readonly();
 
             // Find key 5
-            cursor.find(5);
+            cursor.find_u64(5);
             let mut buf = [0u8; 8];
             cursor
                 .get_entry()
@@ -1785,7 +1823,7 @@ mod test {
             let mut cursor_handle = btree.open(root);
             let mut cursor = cursor_handle.open_readwrite();
             for &key in &keys {
-                cursor.insert(key, key.to_be_bytes().to_vec());
+                cursor.insert_u64(key, key.to_be_bytes().to_vec());
             }
         }
 
@@ -1823,9 +1861,9 @@ mod test {
         {
             let mut cursor_handle = btree.open(root);
             let mut cursor = cursor_handle.open_readwrite();
-            cursor.insert(1, b"one".to_vec());
-            cursor.insert(2, b"two".to_vec());
-            cursor.insert(3, b"three".to_vec());
+            cursor.insert_u64(1, b"one".to_vec());
+            cursor.insert_u64(2, b"two".to_vec());
+            cursor.insert_u64(3, b"three".to_vec());
         }
 
         // Call last() and verify we get key 3
@@ -1856,7 +1894,7 @@ mod test {
             let mut cursor_handle = btree.open(root);
             let mut cursor = cursor_handle.open_readwrite();
             for i in 0..100u64 {
-                cursor.insert(i, i.to_be_bytes().to_vec());
+                cursor.insert_u64(i, i.to_be_bytes().to_vec());
             }
         }
 
@@ -1888,7 +1926,7 @@ mod test {
             let mut cursor_handle = btree.open(root);
             let mut cursor = cursor_handle.open_readwrite();
             for i in 1..=5u64 {
-                cursor.insert(i, i.to_be_bytes().to_vec());
+                cursor.insert_u64(i, i.to_be_bytes().to_vec());
             }
         }
 
@@ -1925,14 +1963,14 @@ mod test {
         {
             let mut cursor_handle = btree.open(root);
             let mut cursor = cursor_handle.open_readwrite();
-            cursor.insert(42, b"the answer".to_vec());
+            cursor.insert_u64(42, b"the answer".to_vec());
         }
 
         // find(42) should return true
         {
             let mut cursor_handle = btree.open(root);
             let mut cursor = cursor_handle.open_readonly();
-            let found = cursor.find(42);
+            let found = cursor.find_u64(42);
             assert!(found, "find() should return true for existing key");
 
             // Verify we can read the value
@@ -1957,16 +1995,16 @@ mod test {
         {
             let mut cursor_handle = btree.open(root);
             let mut cursor = cursor_handle.open_readwrite();
-            cursor.insert(1, b"one".to_vec());
-            cursor.insert(3, b"three".to_vec());
-            cursor.insert(5, b"five".to_vec());
+            cursor.insert_u64(1, b"one".to_vec());
+            cursor.insert_u64(3, b"three".to_vec());
+            cursor.insert_u64(5, b"five".to_vec());
         }
 
         // find(2) should return false (2 doesn't exist)
         {
             let mut cursor_handle = btree.open(root);
             let mut cursor = cursor_handle.open_readonly();
-            let found = cursor.find(2);
+            let found = cursor.find_u64(2);
             assert!(!found, "find() should return false for non-existent key");
         }
 
@@ -1974,7 +2012,7 @@ mod test {
         {
             let mut cursor_handle = btree.open(root);
             let mut cursor = cursor_handle.open_readonly();
-            let found = cursor.find(4);
+            let found = cursor.find_u64(4);
             assert!(!found, "find() should return false for non-existent key");
         }
     }
@@ -1989,14 +2027,14 @@ mod test {
         {
             let mut cursor_handle = btree.open(root);
             let mut cursor = cursor_handle.open_readwrite();
-            cursor.insert(42, b"hello".to_vec());
+            cursor.insert_u64(42, b"hello".to_vec());
         }
 
         // Verify it exists
         {
             let mut cursor_handle = btree.open(root);
             let mut cursor = cursor_handle.open_readonly();
-            let found = cursor.find(42);
+            let found = cursor.find_u64(42);
             assert!(found, "Key 42 should exist before deletion");
         }
 
@@ -2004,14 +2042,14 @@ mod test {
         {
             let mut cursor_handle = btree.open(root);
             let mut cursor = cursor_handle.open_readwrite();
-            cursor.delete(42);
+            cursor.delete_u64(42);
         }
 
         // Verify it's gone
         {
             let mut cursor_handle = btree.open(root);
             let mut cursor = cursor_handle.open_readonly();
-            let found = cursor.find(42);
+            let found = cursor.find_u64(42);
             assert!(!found, "Key 42 should not exist after deletion");
         }
     }
@@ -2026,23 +2064,23 @@ mod test {
         {
             let mut cursor_handle = btree.open(root);
             let mut cursor = cursor_handle.open_readwrite();
-            cursor.insert(10, b"ten".to_vec());
-            cursor.insert(20, b"twenty".to_vec());
+            cursor.insert_u64(10, b"ten".to_vec());
+            cursor.insert_u64(20, b"twenty".to_vec());
         }
 
         // Try to delete a non-existent key (should be no-op)
         {
             let mut cursor_handle = btree.open(root);
             let mut cursor = cursor_handle.open_readwrite();
-            cursor.delete(15); // Key 15 doesn't exist
+            cursor.delete_u64(15); // Key 15 doesn't exist
         }
 
         // Verify original keys still exist
         {
             let mut cursor_handle = btree.open(root);
             let mut cursor = cursor_handle.open_readonly();
-            assert!(cursor.find(10), "Key 10 should still exist");
-            assert!(cursor.find(20), "Key 20 should still exist");
+            assert!(cursor.find_u64(10), "Key 10 should still exist");
+            assert!(cursor.find_u64(20), "Key 20 should still exist");
         }
     }
 
@@ -2058,7 +2096,7 @@ mod test {
             let mut cursor = cursor_handle.open_readwrite();
             for i in 1..=200u64 {
                 let value = format!("value_{}", i).into_bytes();
-                cursor.insert(i, value);
+                cursor.insert_u64(i, value);
             }
         }
 
@@ -2066,16 +2104,16 @@ mod test {
         {
             let mut cursor_handle = btree.open(root);
             let mut cursor = cursor_handle.open_readwrite();
-            cursor.delete(100);
+            cursor.delete_u64(100);
         }
 
         // Verify key 100 is gone but neighbors exist
         {
             let mut cursor_handle = btree.open(root);
             let mut cursor = cursor_handle.open_readonly();
-            assert!(cursor.find(99), "Key 99 should still exist");
-            assert!(!cursor.find(100), "Key 100 should be deleted");
-            assert!(cursor.find(101), "Key 101 should still exist");
+            assert!(cursor.find_u64(99), "Key 99 should still exist");
+            assert!(!cursor.find_u64(100), "Key 100 should be deleted");
+            assert!(cursor.find_u64(101), "Key 101 should still exist");
         }
     }
 
@@ -2090,7 +2128,7 @@ mod test {
             let mut cursor_handle = btree.open(root);
             let mut cursor = cursor_handle.open_readwrite();
             for i in 1..=5u64 {
-                cursor.insert(i, i.to_be_bytes().to_vec());
+                cursor.insert_u64(i, i.to_be_bytes().to_vec());
             }
         }
 
@@ -2098,24 +2136,30 @@ mod test {
         {
             let mut cursor_handle = btree.open(root);
             let mut cursor = cursor_handle.open_readwrite();
-            cursor.delete(3);
+            cursor.delete_u64(3);
         }
 
         // Scan and verify we see 1, 2, 4, 5 (not 3)
         {
+            use super::encode_u64_key;
             let mut cursor_handle = btree.open(root);
             let mut cursor = cursor_handle.open_readonly();
             cursor.first();
 
             let mut keys = Vec::new();
             while let Some(entry) = cursor.get_entry() {
-                keys.push(entry.key());
+                keys.push(entry.key().to_vec());
                 cursor.next();
             }
 
             assert_eq!(
                 keys,
-                vec![1, 2, 4, 5],
+                vec![
+                    encode_u64_key(1),
+                    encode_u64_key(2),
+                    encode_u64_key(4),
+                    encode_u64_key(5)
+                ],
                 "Should see all keys except deleted key 3"
             );
         }
@@ -2132,7 +2176,7 @@ mod test {
             let mut cursor_handle = btree.open(root);
             let mut cursor = cursor_handle.open_readwrite();
             for i in 1..=10u64 {
-                cursor.insert(i, i.to_be_bytes().to_vec());
+                cursor.insert_u64(i, i.to_be_bytes().to_vec());
             }
         }
 
@@ -2141,7 +2185,7 @@ mod test {
             let mut cursor_handle = btree.open(root);
             let mut cursor = cursor_handle.open_readwrite();
             for i in 1..=10u64 {
-                cursor.delete(i);
+                cursor.delete_u64(i);
             }
         }
 
@@ -2172,10 +2216,12 @@ mod test {
         // Insert some values
         {
             let mut cursor = cursor_handle.open_readwrite();
-            cursor.insert(1, b"one".to_vec());
-            cursor.insert(2, b"two".to_vec());
-            cursor.insert(3, b"three".to_vec());
+            cursor.insert_u64(1, b"one".to_vec());
+            cursor.insert_u64(2, b"two".to_vec());
+            cursor.insert_u64(3, b"three".to_vec());
         }
+
+        use super::encode_u64_key;
 
         // After first(), should be Valid
         {
@@ -2185,7 +2231,10 @@ mod test {
                 cursor.cursor_state.position,
                 CursorPosition::Valid { .. }
             ));
-            assert_eq!(cursor.get_entry().unwrap().key(), 1);
+            assert_eq!(
+                cursor.get_entry().unwrap().key(),
+                encode_u64_key(1).as_slice()
+            );
         }
 
         // Navigate through all entries
@@ -2197,14 +2246,20 @@ mod test {
                 cursor.cursor_state.position,
                 CursorPosition::Valid { .. }
             ));
-            assert_eq!(cursor.get_entry().unwrap().key(), 2);
+            assert_eq!(
+                cursor.get_entry().unwrap().key(),
+                encode_u64_key(2).as_slice()
+            );
 
             cursor.next(); // Move to key 3
             assert!(matches!(
                 cursor.cursor_state.position,
                 CursorPosition::Valid { .. }
             ));
-            assert_eq!(cursor.get_entry().unwrap().key(), 3);
+            assert_eq!(
+                cursor.get_entry().unwrap().key(),
+                encode_u64_key(3).as_slice()
+            );
 
             cursor.next(); // Move past end
             assert_eq!(cursor.cursor_state.position, CursorPosition::AtEnd);
@@ -2234,21 +2289,25 @@ mod test {
             let mut cursor_handle = btree.open(root);
             let mut cursor = cursor_handle.open_readwrite();
             for i in 1..=5u64 {
-                cursor.insert(i, i.to_be_bytes().to_vec());
+                cursor.insert_u64(i, i.to_be_bytes().to_vec());
             }
         }
 
         // Position at key 3, delete it, verify next() gives us 4
         {
+            use super::encode_u64_key;
             let mut cursor_handle = btree.open(root);
             let mut cursor = cursor_handle.open_readwrite();
-            cursor.find(3);
+            cursor.find_u64(3);
             cursor.delete_current();
 
             // After delete, cursor is in RequiresSeek state with saved_key=3
             // next() should call ensure_positioned() -> find(3) -> lands on 4
             cursor.next();
-            assert_eq!(cursor.get_entry().unwrap().key(), 4);
+            assert_eq!(
+                cursor.get_entry().unwrap().key(),
+                encode_u64_key(4).as_slice()
+            );
         }
     }
 
@@ -2264,7 +2323,7 @@ mod test {
             let mut cursor_handle = btree.open(root);
             let mut cursor = cursor_handle.open_readwrite();
             for i in 1..=3u64 {
-                cursor.insert(i, i.to_be_bytes().to_vec());
+                cursor.insert_u64(i, i.to_be_bytes().to_vec());
             }
         }
 
@@ -2272,7 +2331,7 @@ mod test {
         {
             let mut cursor_handle = btree.open(root);
             let mut cursor = cursor_handle.open_readwrite();
-            cursor.find(3);
+            cursor.find_u64(3);
             cursor.delete_current();
             cursor.next();
             assert_eq!(cursor.cursor_state.position, CursorPosition::AtEnd);
@@ -2291,20 +2350,24 @@ mod test {
         {
             let mut cursor_handle = btree.open(root);
             let mut cursor = cursor_handle.open_readwrite();
-            cursor.insert(1, b"one".to_vec());
-            cursor.insert(3, b"three".to_vec());
-            cursor.insert(5, b"five".to_vec());
+            cursor.insert_u64(1, b"one".to_vec());
+            cursor.insert_u64(3, b"three".to_vec());
+            cursor.insert_u64(5, b"five".to_vec());
         }
 
         // Position at key 1, insert key 2, verify we can continue iteration
         {
+            use super::encode_u64_key;
             let mut cursor_handle = btree.open(root);
             let mut cursor = cursor_handle.open_readwrite();
-            cursor.find(1);
-            cursor.insert(2, b"two".to_vec());
+            cursor.find_u64(1);
+            cursor.insert_u64(2, b"two".to_vec());
             // After insert, cursor is in RequiresSeek state with saved_key=1
             cursor.next();
-            assert_eq!(cursor.get_entry().unwrap().key(), 2);
+            assert_eq!(
+                cursor.get_entry().unwrap().key(),
+                encode_u64_key(2).as_slice()
+            );
         }
     }
 
@@ -2320,25 +2383,32 @@ mod test {
             let mut cursor_handle = btree.open(root);
             let mut cursor = cursor_handle.open_readwrite();
             for i in 1..=50u64 {
-                cursor.insert(i, format!("value_{}", i).into_bytes());
+                cursor.insert_u64(i, format!("value_{}", i).into_bytes());
             }
         }
 
         // Position at key 10, insert more keys to force split, verify iteration
         {
+            use super::encode_u64_key;
             let mut cursor_handle = btree.open(root);
             let mut cursor = cursor_handle.open_readwrite();
-            cursor.find(10);
+            cursor.find_u64(10);
 
             // Insert 50 more keys to force splits
             for i in 51..=100u64 {
-                cursor.insert(i, format!("value_{}", i).into_bytes());
+                cursor.insert_u64(i, format!("value_{}", i).into_bytes());
             }
 
             // Cursor should still be able to navigate from key 10
-            assert_eq!(cursor.get_entry().unwrap().key(), 10);
+            assert_eq!(
+                cursor.get_entry().unwrap().key(),
+                encode_u64_key(10).as_slice()
+            );
             cursor.next();
-            assert_eq!(cursor.get_entry().unwrap().key(), 11);
+            assert_eq!(
+                cursor.get_entry().unwrap().key(),
+                encode_u64_key(11).as_slice()
+            );
         }
     }
 
@@ -2354,7 +2424,7 @@ mod test {
             let mut cursor_handle = btree.open(root);
             let mut cursor = cursor_handle.open_readwrite();
             for i in 1..=10u64 {
-                cursor.insert(i, i.to_be_bytes().to_vec());
+                cursor.insert_u64(i, i.to_be_bytes().to_vec());
             }
         }
 
@@ -2393,20 +2463,21 @@ mod test {
             let mut cursor_handle = btree.open(root);
             let mut cursor = cursor_handle.open_readwrite();
             for i in 1..=3u64 {
-                cursor.insert(i, i.to_be_bytes().to_vec());
+                cursor.insert_u64(i, i.to_be_bytes().to_vec());
             }
         }
 
         // Position at key 2, delete it, verify get_entry() still works
         {
+            use super::encode_u64_key;
             let mut cursor_handle = btree.open(root);
             let mut cursor = cursor_handle.open_readwrite();
-            cursor.find(2);
+            cursor.find_u64(2);
             cursor.delete_current();
 
             // get_entry() should trigger ensure_positioned() and find key 3
             let entry = cursor.get_entry().unwrap();
-            assert_eq!(entry.key(), 3);
+            assert_eq!(entry.key(), encode_u64_key(3).as_slice());
         }
     }
 
@@ -2418,30 +2489,207 @@ mod test {
         let root = btree.create_tree();
 
         {
+            use super::encode_u64_key;
             let mut cursor_handle = btree.open(root);
             let mut cursor = cursor_handle.open_readwrite();
 
             // Insert multiple values
-            cursor.insert(1, b"value1".to_vec());
-            cursor.insert(2, b"value2".to_vec());
-            cursor.insert(3, b"value3".to_vec());
+            cursor.insert_u64(1, b"value1".to_vec());
+            cursor.insert_u64(2, b"value2".to_vec());
+            cursor.insert_u64(3, b"value3".to_vec());
 
             // Position using first()
             cursor.first();
 
             // Should be positioned on first entry
             let entry = cursor.get_entry().expect("Should find first entry");
-            assert_eq!(entry.key(), 1);
+            assert_eq!(entry.key(), encode_u64_key(1).as_slice());
 
             // Navigate to next
             cursor.next();
             let entry = cursor.get_entry().expect("Should find second entry");
-            assert_eq!(entry.key(), 2);
+            assert_eq!(entry.key(), encode_u64_key(2).as_slice());
 
             // Navigate to next again
             cursor.next();
             let entry = cursor.get_entry().expect("Should find third entry");
-            assert_eq!(entry.key(), 3);
+            assert_eq!(entry.key(), encode_u64_key(3).as_slice());
+        }
+    }
+
+    // ========================================================================
+    // Variable-length key tests (Step 41.7)
+    // ========================================================================
+
+    #[test]
+    fn test_variable_length_keys_ordering() {
+        // Keys of different lengths should sort lexicographically:
+        // "a" < "ab" < "abc" < "b"
+        let test = TestDb::default();
+        let mut btree = test.btree;
+        let root = btree.create_tree();
+
+        let keys: Vec<&[u8]> = vec![b"abc", b"b", b"a", b"ab"];
+        {
+            let mut cursor_handle = btree.open(root);
+            let mut cursor = cursor_handle.open_readwrite();
+            for key in &keys {
+                cursor.insert(key, b"value".to_vec());
+            }
+        }
+
+        // Scan and verify sorted order
+        {
+            let mut cursor_handle = btree.open(root);
+            let mut cursor = cursor_handle.open_readonly();
+            cursor.first();
+
+            let expected_order: Vec<&[u8]> = vec![b"a", b"ab", b"abc", b"b"];
+            for expected_key in expected_order {
+                let entry = cursor.get_entry().expect("Should have entry");
+                assert_eq!(entry.key(), expected_key);
+                cursor.next();
+            }
+            assert!(cursor.get_entry().is_none(), "Should be at end");
+        }
+    }
+
+    #[test]
+    fn test_variable_length_keys_long_key() {
+        // Keys up to 1KB should work correctly
+        let test = TestDb::default();
+        let mut btree = test.btree;
+        let root = btree.create_tree();
+
+        let long_key: Vec<u8> = (0u8..=255).cycle().take(1024).collect();
+        let short_key: Vec<u8> = b"short".to_vec();
+        let medium_key: Vec<u8> = b"medium_length_key_here".to_vec();
+
+        {
+            let mut cursor_handle = btree.open(root);
+            let mut cursor = cursor_handle.open_readwrite();
+            cursor.insert(&long_key, b"long_value".to_vec());
+            cursor.insert(&short_key, b"short_value".to_vec());
+            cursor.insert(&medium_key, b"medium_value".to_vec());
+        }
+
+        // Verify long key can be found and read back
+        {
+            let mut cursor_handle = btree.open(root);
+            let mut cursor = cursor_handle.open_readonly();
+            let found = cursor.find(&long_key);
+            assert!(found, "Long key should be found");
+            let entry = cursor.get_entry().unwrap();
+            assert_eq!(entry.key(), long_key.as_slice());
+        }
+
+        // Verify short key can be found
+        {
+            let mut cursor_handle = btree.open(root);
+            let mut cursor = cursor_handle.open_readonly();
+            let found = cursor.find(&short_key);
+            assert!(found, "Short key should be found");
+        }
+    }
+
+    #[test]
+    fn test_variable_length_keys_mixed_lengths() {
+        // Mix of 1-byte, 4-byte, 8-byte, and 16-byte keys should all sort correctly
+        let test = TestDb::default();
+        let mut btree = test.btree;
+        let root = btree.create_tree();
+
+        let keys: Vec<Vec<u8>> = vec![
+            vec![0x01],
+            vec![0x00, 0x00, 0x00, 0x01],
+            vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01],
+            vec![0x00; 16],
+            vec![0xFF],
+            vec![0x00, 0xFF],
+        ];
+
+        {
+            let mut cursor_handle = btree.open(root);
+            let mut cursor = cursor_handle.open_readwrite();
+            for key in &keys {
+                cursor.insert(key, b"v".to_vec());
+            }
+        }
+
+        // Scan and verify they come back in sorted order
+        {
+            let mut cursor_handle = btree.open(root);
+            let mut cursor = cursor_handle.open_readonly();
+            cursor.first();
+
+            let mut prev_key: Vec<u8> = vec![];
+            let mut count = 0;
+            while let Some(entry) = cursor.get_entry() {
+                let k = entry.key().to_vec();
+                assert!(
+                    k > prev_key,
+                    "Keys must be strictly increasing: {:?} > {:?}",
+                    k,
+                    prev_key
+                );
+                prev_key = k;
+                count += 1;
+                cursor.next();
+            }
+            assert_eq!(count, keys.len(), "All keys should be present");
+        }
+    }
+
+    #[test]
+    fn test_variable_length_keys_splits() {
+        // Insert many variable-length keys to trigger B-tree splits
+        let test = TestDb::default();
+        let mut btree = test.btree;
+        let root = btree.create_tree();
+
+        // Generate variable-length keys of varying sizes
+        let mut keys: Vec<Vec<u8>> = (0u32..200)
+            .map(|i| {
+                let len = 1 + (i as usize % 20); // lengths 1..20
+                let mut k = vec![0u8; len];
+                k[0] = (i >> 8) as u8;
+                if len > 1 {
+                    k[1] = (i & 0xFF) as u8;
+                }
+                k
+            })
+            .collect();
+
+        // Deduplicate and sort to get the canonical set
+        keys.sort();
+        keys.dedup();
+        let num_keys = keys.len();
+
+        {
+            let mut cursor_handle = btree.open(root);
+            let mut cursor = cursor_handle.open_readwrite();
+            for key in &keys {
+                cursor.insert(key, b"val".to_vec());
+            }
+            cursor.verify().unwrap();
+        }
+
+        // Scan and verify all keys present in sorted order
+        {
+            let mut cursor_handle = btree.open(root);
+            let mut cursor = cursor_handle.open_readonly();
+            cursor.first();
+
+            let mut count = 0;
+            let mut prev_key: Vec<u8> = vec![];
+            while let Some(entry) = cursor.get_entry() {
+                let k = entry.key().to_vec();
+                assert!(k > prev_key, "Keys must be strictly increasing");
+                prev_key = k;
+                count += 1;
+                cursor.next();
+            }
+            assert_eq!(count, num_keys, "All keys should be accessible after splits");
         }
     }
 }

--- a/src/storage/cell.rs
+++ b/src/storage/cell.rs
@@ -1,6 +1,6 @@
 use serde::{de::Visitor, Deserialize, Serialize};
 
-pub type Key = u64;
+pub type Key = Vec<u8>;
 pub type Value = Vec<u8>;
 pub type ValueRef<'a> = &'a [u8];
 
@@ -20,8 +20,8 @@ impl Cell {
         }
     }
 
-    pub fn key(&self) -> Key {
-        self.key
+    pub fn key(&self) -> &[u8] {
+        &self.key
     }
 
     pub fn value(&self) -> ValueRef<'_> {
@@ -47,7 +47,7 @@ impl Serialize for Cell {
 
 struct CellDeserializeVisitor;
 impl<'de> Visitor<'de> for CellDeserializeVisitor {
-    type Value = (u64, Vec<u8>, Option<u32>);
+    type Value = (Vec<u8>, Vec<u8>, Option<u32>);
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
         formatter.write_str("an array of two or three values")
@@ -57,8 +57,8 @@ impl<'de> Visitor<'de> for CellDeserializeVisitor {
     where
         A: serde::de::SeqAccess<'de>,
     {
-        let key = seq.next_element()?.unwrap();
-        let value = seq.next_element()?.unwrap();
+        let key: Vec<u8> = seq.next_element()?.unwrap();
+        let value: Vec<u8> = seq.next_element()?.unwrap();
         let continuation = seq.next_element()?;
 
         Ok((key, value, continuation))
@@ -86,9 +86,9 @@ mod tests {
 
     #[test]
     fn test_cell_cbor_roundtrip() {
-        let key = 12345u64;
+        let key = vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x30, 0x39]; // 12345u64.to_be_bytes()
         let value = b"test value".to_vec();
-        let cell = Cell::new(key, value.clone(), None);
+        let cell = Cell::new(key.clone(), value.clone(), None);
 
         // Serialize with CBOR
         let mut cbor = Vec::new();
@@ -97,17 +97,17 @@ mod tests {
         // Deserialize from CBOR
         let decoded: Cell = ciborium::de::from_reader(&cbor[..]).unwrap();
 
-        assert_eq!(decoded.key(), key);
+        assert_eq!(decoded.key(), key.as_slice());
         assert_eq!(decoded.value(), value.as_slice());
         assert_eq!(decoded.continuation(), None);
     }
 
     #[test]
     fn test_cell_cbor_roundtrip_with_continuation() {
-        let key = 99u64;
+        let key = vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x63]; // 99u64.to_be_bytes()
         let value = b"overflow data".to_vec();
         let continuation = Some(42u32);
-        let cell = Cell::new(key, value.clone(), continuation);
+        let cell = Cell::new(key.clone(), value.clone(), continuation);
 
         // Serialize with CBOR
         let mut cbor = Vec::new();
@@ -116,8 +116,26 @@ mod tests {
         // Deserialize from CBOR
         let decoded: Cell = ciborium::de::from_reader(&cbor[..]).unwrap();
 
-        assert_eq!(decoded.key(), key);
+        assert_eq!(decoded.key(), key.as_slice());
         assert_eq!(decoded.value(), value.as_slice());
         assert_eq!(decoded.continuation(), continuation);
+    }
+
+    #[test]
+    fn test_cell_variable_length_keys() {
+        // Short key
+        let short_key = vec![0x01];
+        let cell = Cell::new(short_key.clone(), b"v".to_vec(), None);
+        assert_eq!(cell.key(), short_key.as_slice());
+
+        // Long key (1KB)
+        let long_key = vec![0xABu8; 1024];
+        let cell = Cell::new(long_key.clone(), b"v".to_vec(), None);
+        assert_eq!(cell.key(), long_key.as_slice());
+
+        // Empty key
+        let empty_key = vec![];
+        let cell = Cell::new(empty_key.clone(), b"v".to_vec(), None);
+        assert_eq!(cell.key(), empty_key.as_slice());
     }
 }

--- a/src/storage/cell_reader.rs
+++ b/src/storage/cell_reader.rs
@@ -1,12 +1,11 @@
 use crate::engine::scalarvalue::ScalarValue;
 
-use super::cell::Key;
 use super::node::NodePage;
 use super::pager::Pager;
 
 pub struct CellReader<'a> {
     pager: &'a Pager,
-    key: Key,
+    key: Vec<u8>,
     continuation: Option<u32>,
 
     // Owned buffer - safe, no dangling pointers
@@ -55,7 +54,7 @@ impl<'a> CellReader<'a> {
             .expect("Values are always supposed to be in leaf pages");
 
         let cell = leaf_page.get_item_at_index(cell_idx)?;
-        let key = cell.key();
+        let key = cell.key().to_vec();
         let continuation = cell.continuation();
         let value = cell.value();
 
@@ -71,8 +70,9 @@ impl<'a> CellReader<'a> {
         })
     }
 
-    pub fn key(&self) -> Key {
-        self.key
+    /// Returns the raw key bytes for this cell.
+    pub fn key(&self) -> &[u8] {
+        &self.key
     }
 
     pub fn decode_as_array(&mut self) -> Vec<ScalarValue> {
@@ -99,7 +99,7 @@ mod tests {
         {
             let mut cursor_handle = btree.open(root_page);
             let mut cursor = cursor_handle.open_readwrite();
-            cursor.insert(key, value.clone());
+            cursor.insert_u64(key, value.clone());
         }
 
         // Read it back with CellReader
@@ -109,7 +109,7 @@ mod tests {
             cursor.first();
 
             let mut reader = cursor.get_entry().unwrap();
-            assert_eq!(reader.key(), key);
+            assert_eq!(reader.key(), crate::storage::encode_u64_key(key).as_slice());
 
             let mut buf = Vec::new();
             reader.read_to_end(&mut buf).unwrap();
@@ -131,7 +131,7 @@ mod tests {
         {
             let mut cursor_handle = btree.open(root_page);
             let mut cursor = cursor_handle.open_readwrite();
-            cursor.insert(key, value_json.clone());
+            cursor.insert_u64(key, value_json.clone());
         }
 
         // Read it back with CellReader
@@ -141,7 +141,7 @@ mod tests {
             cursor.first();
 
             let mut reader = cursor.get_entry().unwrap();
-            assert_eq!(reader.key(), key);
+            assert_eq!(reader.key(), crate::storage::encode_u64_key(key).as_slice());
 
             let mut buf = Vec::new();
             reader.read_to_end(&mut buf).unwrap();
@@ -167,7 +167,7 @@ mod tests {
         {
             let mut cursor_handle = btree.open(root_page);
             let mut cursor = cursor_handle.open_readwrite();
-            cursor.insert(key, value_json.clone());
+            cursor.insert_u64(key, value_json.clone());
         }
 
         // Read it back with CellReader
@@ -177,7 +177,7 @@ mod tests {
             cursor.first();
 
             let mut reader = cursor.get_entry().unwrap();
-            assert_eq!(reader.key(), key);
+            assert_eq!(reader.key(), crate::storage::encode_u64_key(key).as_slice());
 
             let mut buf = Vec::new();
             reader.read_to_end(&mut buf).unwrap();
@@ -207,7 +207,7 @@ mod tests {
         {
             let mut cursor_handle = btree.open(root_page);
             let mut cursor = cursor_handle.open_readwrite();
-            cursor.insert(key, value_bytes.clone());
+            cursor.insert_u64(key, value_bytes.clone());
         }
 
         // Read it back with CellReader
@@ -246,7 +246,7 @@ mod tests {
         {
             let mut cursor_handle = btree.open(root_page);
             let mut cursor = cursor_handle.open_readwrite();
-            cursor.insert(key, value_bytes.clone());
+            cursor.insert_u64(key, value_bytes.clone());
         }
 
         // Read it back with CellReader
@@ -281,7 +281,7 @@ mod tests {
         {
             let mut cursor_handle = btree.open(root_page);
             let mut cursor = cursor_handle.open_readwrite();
-            cursor.insert(key, value_bytes.clone());
+            cursor.insert_u64(key, value_bytes.clone());
         }
 
         // Read it back with CellReader

--- a/src/storage/node.rs
+++ b/src/storage/node.rs
@@ -12,7 +12,7 @@ pub enum NodePage {
 }
 
 impl NodePage {
-    pub fn search(&self, k: &Key) -> SearchResult {
+    pub fn search(&self, k: &[u8]) -> SearchResult {
         match self {
             NodePage::Leaf(l) => l.search(k),
             NodePage::Interior(i) => i.search(k),
@@ -58,7 +58,7 @@ impl NodePage {
 
     pub fn smallest_key(&self) -> Key {
         match self {
-            NodePage::Leaf(l) => l.cells.first().unwrap().key().clone(),
+            NodePage::Leaf(l) => l.cells.first().unwrap().key().to_vec(),
             NodePage::Interior(i) => i.keys.first().unwrap().clone(),
             _ => panic!(),
         }
@@ -66,7 +66,7 @@ impl NodePage {
 
     pub fn largest_key(&self) -> Key {
         match self {
-            NodePage::Leaf(l) => l.cells.last().unwrap().key().clone(),
+            NodePage::Leaf(l) => l.cells.last().unwrap().key().to_vec(),
             NodePage::Interior(i) => i.keys.last().unwrap().clone(),
             _ => panic!(),
         }
@@ -111,11 +111,11 @@ pub enum SearchResult {
 }
 
 impl LeafNodePage {
-    pub fn search(&self, search_key: &Key) -> SearchResult {
+    pub fn search(&self, search_key: &[u8]) -> SearchResult {
         // Simple linear search through the page.
         for (index, cell) in self.cells.iter().enumerate() {
             let cell_key = cell.key();
-            match search_key.cmp(&cell_key) {
+            match search_key.cmp(cell_key) {
                 Less => return SearchResult::NotPresent(index),
                 Equal => return SearchResult::Found(index),
                 Greater => {} // Continue the search
@@ -148,21 +148,15 @@ impl LeafNodePage {
     }
 
     pub fn get_key(&self, index: usize) -> Key {
-        self.cells[index].key()
+        self.cells[index].key().to_vec()
     }
 
     pub fn verify_key_ordering(&self) -> Result<(), VerifyError> {
-        let keys = || self.cells.iter().map(Cell::key);
-
-        for (left, right) in keys().zip(keys()) {
-            match left.cmp(&right) {
-                Less | Equal => { /* GOOD! */ }
-                Greater => {
-                    return Err(VerifyError::KeyOutOfOrder);
-                }
+        for window in self.cells.windows(2) {
+            if window[0].key() > window[1].key() {
+                return Err(VerifyError::KeyOutOfOrder);
             }
         }
-
         Ok(())
     }
 
@@ -223,17 +217,11 @@ impl InteriorNodePage {
     }
 
     pub fn verify_key_ordering(&self) -> Result<(), VerifyError> {
-        let keys = || self.keys.iter();
-
-        for (left, right) in keys().zip(keys()) {
-            match left.cmp(right) {
-                Less | Equal => { /* GOOD! */ }
-                Greater => {
-                    return Err(VerifyError::KeyOutOfOrder);
-                }
+        for window in self.keys.windows(2) {
+            if window[0] > window[1] {
+                return Err(VerifyError::KeyOutOfOrder);
             }
         }
-
         Ok(())
     }
 
@@ -241,9 +229,9 @@ impl InteriorNodePage {
         self.keys[edge].clone()
     }
 
-    fn search(&self, k: &Key) -> SearchResult {
+    fn search(&self, k: &[u8]) -> SearchResult {
         for (idx, key) in self.keys.iter().enumerate() {
-            match k.cmp(key) {
+            match k.cmp(key.as_slice()) {
                 Less => {
                     return SearchResult::GoDown(idx, self.edges[idx]);
                 }
@@ -263,7 +251,7 @@ impl InteriorNodePage {
 
     pub fn insert_child_page(&mut self, edge_page_smallest_key: Key, edge_page_idx: u32) {
         for (idx, key) in self.keys.iter().enumerate() {
-            match edge_page_smallest_key.cmp(key) {
+            match edge_page_smallest_key.as_slice().cmp(key.as_slice()) {
                 Less => {
                     self.edges.insert(idx + 1, edge_page_idx);
                     self.keys.insert(idx, edge_page_smallest_key);
@@ -291,17 +279,6 @@ impl InteriorNodePage {
 
           E is no longer required
         */
-
-        // InteriorNodePage {
-        //   keys:    [1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13,14], // len: 14, len/2: 7,
-        //   edges: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1] // len: 15, len/2: 7
-
-        //   left_keys:    [1, 2, 3, 4, 5, 6, 7]
-        //   left_edges: [1, 1, 1, 1, 1, 1, 1, 1]
-
-        //   right_keys:    [9,10,11,12,13,14], // len: 14, len/2: 7,
-        //   right_edges: [1, 1, 1, 1, 1, 1, 1] // len: 15, len/2: 7
-        // }
 
         // invariant each of the two interior pages produced must have at least two child pages and one key
         assert!(self.keys.len() >= 3); // One key is removed in the split
@@ -359,21 +336,25 @@ mod test {
 
     use super::{InteriorNodePage, LeafNodePage, SearchResult};
 
+    fn make_key(k: u64) -> Vec<u8> {
+        k.to_be_bytes().to_vec()
+    }
+
     #[test]
     fn test_insertion_ordering() {
         let mut page = LeafNodePage::default();
 
         // []
-        page.insert_item_at_index(0, Cell::new(2, vec![0], None));
+        page.insert_item_at_index(0, Cell::new(make_key(2), vec![0], None));
         // [2]
-        page.insert_item_at_index(0, Cell::new(1, vec![0], None));
+        page.insert_item_at_index(0, Cell::new(make_key(1), vec![0], None));
         // [1, 2]
-        page.insert_item_at_index(2, Cell::new(3, vec![0], None));
+        page.insert_item_at_index(2, Cell::new(make_key(3), vec![0], None));
         // [1, 2, 3]
 
-        assert_eq!(page.cells[0].key(), 1);
-        assert_eq!(page.cells[1].key(), 2);
-        assert_eq!(page.cells[2].key(), 3);
+        assert_eq!(page.cells[0].key(), make_key(1).as_slice());
+        assert_eq!(page.cells[1].key(), make_key(2).as_slice());
+        assert_eq!(page.cells[2].key(), make_key(3).as_slice());
     }
 
     fn found_index(r: SearchResult) -> usize {
@@ -388,30 +369,58 @@ mod test {
     fn test_search() {
         let mut page = LeafNodePage::default();
 
-        page.insert_item_at_index(0, Cell::new(1, vec![0], None));
-        page.insert_item_at_index(1, Cell::new(2, vec![0], None));
-        page.insert_item_at_index(2, Cell::new(3, vec![0], None));
+        page.insert_item_at_index(0, Cell::new(make_key(1), vec![0], None));
+        page.insert_item_at_index(1, Cell::new(make_key(2), vec![0], None));
+        page.insert_item_at_index(2, Cell::new(make_key(3), vec![0], None));
 
         println!("Page: {:?}", page);
-        assert_eq!(0, found_index(page.search(&1)));
-        assert_eq!(1, found_index(page.search(&2)));
-        assert_eq!(2, found_index(page.search(&3)));
+        assert_eq!(0, found_index(page.search(&make_key(1))));
+        assert_eq!(1, found_index(page.search(&make_key(2))));
+        assert_eq!(2, found_index(page.search(&make_key(3))));
+    }
+
+    #[test]
+    fn test_lexicographic_ordering() {
+        // Verify that byte-slice comparison maintains lexicographic order.
+        // Keys "a" < "ab" < "b" < "ba"
+        let mut page = LeafNodePage::default();
+
+        let keys: Vec<Vec<u8>> = vec![b"a".to_vec(), b"ab".to_vec(), b"b".to_vec(), b"ba".to_vec()];
+
+        for (idx, key) in keys.iter().enumerate() {
+            let result = page.search(key);
+            match result {
+                SearchResult::NotPresent(i) => {
+                    page.insert_item_at_index(i, Cell::new(key.clone(), vec![idx as u8], None))
+                }
+                SearchResult::Found(_) => panic!("Unexpected duplicate"),
+                SearchResult::GoDown(_, _) => panic!(),
+            }
+        }
+
+        page.verify_key_ordering().unwrap();
+        assert_eq!(page.num_items(), 4);
+        assert_eq!(page.cells[0].key(), b"a");
+        assert_eq!(page.cells[1].key(), b"ab");
+        assert_eq!(page.cells[2].key(), b"b");
+        assert_eq!(page.cells[3].key(), b"ba");
     }
 
     use proptest::prelude::*;
 
     proptest! {
         #[test]
-        fn test_split(insertions in prop::collection::vec(&(0..100u64, 0..1000u64),0..100usize)) {
+        fn test_split(insertions in prop::collection::vec((0..100u64, 0..1000u64),0..100usize)) {
             let mut page = LeafNodePage::default();
 
             // Count num unique keys
             let n = insertions.iter().map(|(k,_)| k).collect::<HashSet<_>>().len();
 
             for (key, value) in insertions {
+                let key_bytes = key.to_be_bytes().to_vec();
                 let value = value.to_be_bytes().to_vec();
-                let cell = Cell::new(key, value, None);
-                let result = page.search(&key);
+                let cell = Cell::new(key_bytes.clone(), value, None);
+                let result = page.search(&key_bytes);
                 match result {
                     SearchResult::Found(idx) => page.set_item_at_index(idx, cell),
                     SearchResult::NotPresent(idx) => page.insert_item_at_index(idx, cell),
@@ -424,11 +433,7 @@ mod test {
             // Page has N elements, one for each unique key
             assert_eq!(n, page.num_items());
 
-            // println!("both {page:?}");
-
             let (left, right) = page.split();
-
-            // println!("left {left:?} <-> right {right:?}");
 
             // No items were lost in the making of these parts
             assert_eq!(left.num_items() + right.num_items(), n);
@@ -456,12 +461,12 @@ mod test {
 
           E is no longer required
         */
-        let (w, e, r) = (1, 2, 3);
-        let (a, s, d, f) = (10, 20, 30, 40);
+        let (w, e, r) = (make_key(1), make_key(2), make_key(3));
+        let (a, s, d, f) = (10u32, 20u32, 30u32, 40u32);
 
-        let mut interior_node = InteriorNodePage::new(a, w, s);
-        interior_node.insert_child_page(e, d);
-        interior_node.insert_child_page(r, f);
+        let mut interior_node = InteriorNodePage::new(a, w.clone(), s);
+        interior_node.insert_child_page(e.clone(), d);
+        interior_node.insert_child_page(r.clone(), f);
 
         assert_eq!(interior_node.edges, &[a, s, d, f]);
         assert_eq!(interior_node.keys, &[w, e, r]);
@@ -469,21 +474,20 @@ mod test {
         let (left, right) = interior_node.split();
 
         assert_eq!(left.edges, &[a, s]);
-        assert_eq!(left.keys, &[w]);
+        assert_eq!(left.keys, &[make_key(1)]);
 
         assert_eq!(right.edges, &[d, f]);
-        assert_eq!(right.keys, &[r]);
+        assert_eq!(right.keys, &[make_key(3)]);
     }
 
     proptest! {
         #[test]
         fn test_interior_page_split(interior_num_edges in 4u64..150) {
             let num_inserts = interior_num_edges-2; // there are already two edges in the interior page
-            let mut interior_node = InteriorNodePage::new(1, 1, 1);
+            let mut interior_node = InteriorNodePage::new(1, make_key(1), 1);
             for page in 0..num_inserts {
-                interior_node.insert_child_page(page+2,1);
+                interior_node.insert_child_page(make_key(page+2), 1);
             }
-            // println!("{interior_node:?}");
             let (_left, _right) = interior_node.split();
         }
     }

--- a/src/testing/sql_runner.rs
+++ b/src/testing/sql_runner.rs
@@ -47,6 +47,9 @@ fn execute_sql_script(sql_path: &PathBuf) -> Vec<String> {
                 ExecuteResult::CreateTable { table_name } => {
                     actual_output.push(format!("Table '{}' created", table_name));
                 }
+                ExecuteResult::CreateIndex { index_name } => {
+                    actual_output.push(format!("Index '{}' created", index_name));
+                }
                 ExecuteResult::DropTable { table_name } => {
                     actual_output.push(format!("Table '{}' dropped", table_name));
                 }

--- a/tests/sql/create_index.expected
+++ b/tests/sql/create_index.expected
@@ -1,0 +1,5 @@
+Table 'users' created
+1
+1
+1
+Index 'idx_age' created

--- a/tests/sql/create_index.sql
+++ b/tests/sql/create_index.sql
@@ -1,0 +1,5 @@
+CREATE TABLE users (id INTEGER, name TEXT, age INTEGER)
+INSERT INTO users VALUES (1, 'Alice', 30)
+INSERT INTO users VALUES (2, 'Bob', 25)
+INSERT INTO users VALUES (3, 'Charlie', 30)
+CREATE INDEX idx_age ON users(age)


### PR DESCRIPTION
Change B-tree key type from fixed u64 to Vec<u8>/&[u8] throughout the storage stack, enabling arbitrary-length keys for index support.

- cell.rs/cell_reader.rs/node.rs: Key is now Vec<u8>, accessors return &[u8]
- btree.rs: Primary API insert/find/delete take &[u8]; add insert_u64/find_u64/ delete_u64 convenience wrappers; add encode_u64_key/decode_u64_key and update
  encode/decode_integer_key to use Vec<u8>; add 4 variable-length key tests
- storage.rs: Re-export encode_u64_key/decode_u64_key
- engine.rs/db.rs/compiler/planner/repl: Update all call sites to use the new u64 convenience wrappers or byte-slice API

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>