### PR TITLE
Plan: Phase K — Inline SQL Test Expected Output + new-plan skill

### DIFF
--- a/.claude/skills/new-plan/SKILL.md
+++ b/.claude/skills/new-plan/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: new-plan
+description: Add a new phase plan to the development roadmap
+tags: [workflow, planning]
+---
+
+# New Plan Skill
+
+You are helping the user design and document a new phase for the database development roadmap.
+
+## Context to Gather First
+
+Before writing anything, collect the context you need:
+
+1. Read `doc/plan/README.md` to understand the existing phases, current phase naming convention (A, B, C … G, G2, G4, H, I, J, K …), and the next available phase letter/number.
+2. Scan `doc/plan/` (excluding `completed/`) to see any in-progress or planned phases that the new phase might depend on or follow.
+3. Read one or two recent phase files to internalize the expected document structure and level of detail.
+
+## User Input
+
+Use AskUserQuestion to ask the user:
+- What feature or improvement should the new phase cover?
+- Are there any specific implementation approaches or constraints they have in mind?
+
+Keep the question open-ended — the user may have given a description already in their prompt; if so, skip asking and use that.
+
+## Determine the Phase Identifier
+
+Pick the next available phase identifier following the existing sequence visible in `doc/plan/README.md`. Use a letter (e.g. `L`) or a numbered suffix (e.g. `G5`) depending on the context of the phase.
+
+## Write the Plan File
+
+Create `doc/plan/phase-<id>-<short-slug>.md` following the structure used in existing phase files:
+
+```markdown
+# Phase <ID> — <Title>
+
+One sentence describing the goal of this phase.
+
+## Items
+
+| # | Track | Item | Depends on |
+|---|-------|------|------------|
+| N | X.Y   | Description | — or phase |
+
+---
+Important: Each item should be committed separately, follow 'Git Workflow' in CLAUDE.md
+
+---
+
+## Overview
+
+Why this phase exists. What problem it solves. How it fits with other phases.
+
+---
+
+## N. Item Title (Track X.Y)
+
+### What Changes
+### Background
+### Implementation Approach
+### Key Files
+### Tests
+### Implementation Steps (N commits)
+
+#### Step N.1 — ...
+**Commit:** ...
+
+---
+
+## Verification
+
+- [ ] Tests pass: `cargo test`
+- [ ] Zero warnings: `cargo fmt && cargo build 2>&1 | grep -i warning`
+- [ ] Each commit is independently testable
+```
+
+Match the depth and detail of the existing plan files. Include concrete code examples, SQL snippets, or file paths where they clarify the approach. Be specific enough that another developer (or Claude) could implement the phase from the document alone.
+
+## Update the README
+
+Add a row to the phase table in `doc/plan/README.md`:
+
+```markdown
+| **<ID>** | <Title> | <item count> | [phase-<id>-<slug>.md](phase-<id>-<slug>.md) | Planned |
+```
+
+Insert it after the last existing row in the table.
+
+## Commit and PR
+
+1. Stage and show the diff for review:
+   ```bash
+   git add doc/plan/
+   git diff --cached --stat
+   ```
+2. Wait for user approval, then commit:
+   ```bash
+   git commit -m "Add Phase <ID> plan: <title>"
+   ```
+3. Push and open a PR:
+   ```bash
+   git push -u origin <branch>
+   gh pr create --title "Plan: Phase <ID> — <title>" --body "..."
+   ```
+
+The PR body should summarise the phase goal, list the items, and note any dependencies on other phases.
+
+## Important Notes
+
+- Do not implement any code — this skill is for planning only.
+- Follow the Git Workflow from CLAUDE.md (small focused commits, review before committing).
+- The plan should be detailed enough to hand off to the `next-phase` skill for implementation.
+- If the user already created a branch before invoking this skill, use that branch rather than creating a new one.

--- a/doc/plan/README.md
+++ b/doc/plan/README.md
@@ -44,6 +44,7 @@ Fill unit test gaps (Cell/CellReader have 0 tests, Pager has 2), build automated
 | **H** | Compiler Type Safety | 1 | [phase-h-compiler-safety.md](completed/phase-h-compiler-safety.md) | Completed |
 | **I** | Bug Fixes | 4 | [phase-i-bug-fixes.md](completed/phase-i-bug-fixes.md) | Completed |
 | **J** | Cleanup and Refactor | 3 | [phase-j-cleanup-and-refactor.md](completed/phase-j-cleanup-and-refactor.md) | Completed |
+| **K** | Inline SQL Test Expected Output | 4 | [phase-k-inline-sql-tests.md](phase-k-inline-sql-tests.md) | Planned |
 
 ## Current Test Coverage (161 tests)
 

--- a/doc/plan/phase-k-inline-sql-tests.md
+++ b/doc/plan/phase-k-inline-sql-tests.md
@@ -1,0 +1,298 @@
+# Phase K — Inline SQL Test Expected Output
+
+Merge `.expected` files into their corresponding `.sql` files so that input and expected output live together, making tests easier to read and review.
+
+## Items
+
+| # | Track | Item | Depends on |
+|---|-------|------|------------|
+| 50 | 7 | New `.sql` file format with inline expected output | — |
+| 51 | 7 | Migrate existing tests to new format | 50 |
+| 52 | 7 | Update `update-sql-tests` tool to write inline output | 51 |
+| 53 | 7 | Remove obsolete `.expected` files | 52 |
+
+---
+Important: Each item should be committed separately, follow 'Git Workflow' in CLAUDE.md
+
+---
+
+## Overview
+
+Currently each SQL test consists of two files:
+
+```
+tests/sql/where_clauses.sql      ← input
+tests/sql/where_clauses.expected ← expected output (separate file)
+```
+
+The separation makes code review hard — the reviewer must switch between two files to understand what each statement does and what it's supposed to produce. The goal of this phase is to merge them into a single self-contained file:
+
+```sql
+-- tests/sql/where_clauses.sql
+CREATE TABLE numbers (id INTEGER, value INTEGER, name TEXT)
+-- > Table 'numbers' created
+INSERT INTO numbers VALUES (1, 100, 'one')
+-- > 1
+SELECT id, value FROM numbers WHERE value=100
+-- > 1	100
+-- > 3	100
+```
+
+The `update-sql-tests` tool is updated to rewrite the inline expected output in place, so the workflow for regenerating expected output is unchanged.
+
+---
+
+## 50. New `.sql` Format with Inline Expected Output (Track 7)
+
+### Format Specification
+
+Each SQL statement is followed immediately by its expected output, expressed as `-- >` comment lines. Multiple output lines are each prefixed with `-- >`. The `-- >` marker is chosen because:
+- It is a valid SQL comment, so the file remains syntactically valid SQL
+- `>` visually suggests "output"
+- It is unambiguous — regular comments use `--` without `>`
+
+```sql
+-- Regular comments (ignored by runner, no output)
+CREATE TABLE numbers (id INTEGER, value INTEGER, name TEXT)
+-- > Table 'numbers' created
+
+INSERT INTO numbers VALUES (1, 100, 'one')
+-- > 1
+
+SELECT id, value FROM numbers WHERE value = 100
+-- > 1	100
+-- > 3	100
+
+-- Error assertions use the same ERROR: prefix convention
+CREATE TABLE numbers (id INTEGER)
+-- > ERROR: already exists
+```
+
+Rules:
+- A `-- >` line immediately following a SQL statement is an expected output line.
+- Multiple consecutive `-- >` lines represent multiple output rows.
+- Regular `--` comments (without `>`) are ignored.
+- Blank lines are ignored.
+- `ERROR:` prefix in expected output retains the existing case-insensitive substring match behaviour.
+
+### Parser Changes (`src/testing/sql_runner.rs`)
+
+Replace the two-file `execute_sql_script` + file read with a single-file parser:
+
+```rust
+struct SqlTestFile {
+    statements: Vec<SqlStatement>,
+}
+
+struct SqlStatement {
+    sql: String,
+    expected: Vec<String>,  // lines after "-- >"
+}
+```
+
+Parsing algorithm:
+1. Iterate lines.
+2. Non-empty, non-comment lines → new `SqlStatement`.
+3. `-- > <text>` lines immediately after a statement → push to that statement's `expected`.
+4. Plain `--` comments and blank lines → skip.
+
+The runner then executes each statement and compares its output against `statement.expected` rather than reading a separate file.
+
+### Key Files
+
+- `src/testing/sql_runner.rs` — parse new format, update `execute_sql_script`, `compare_output`, `update_expected_file`
+- `build.rs` — no change needed (still scans for `.sql` files)
+- `src/bin/update-sql-tests.rs` — no change needed (calls `run_sql_test`)
+
+### Tests
+
+Unit test the new parser directly:
+```rust
+#[test]
+fn test_parse_inline_expected() {
+    let input = "SELECT 1\n-- > 1\nSELECT 2\n-- > 2\n-- > extra\n";
+    let parsed = parse_sql_test_file(input);
+    assert_eq!(parsed[0].sql, "SELECT 1");
+    assert_eq!(parsed[0].expected, vec!["1"]);
+    assert_eq!(parsed[1].sql, "SELECT 2");
+    assert_eq!(parsed[1].expected, vec!["2", "extra"]);
+}
+```
+
+### Implementation Steps (2 commits)
+
+#### Step 50.1 — Parser: read inline expected output
+
+Add `parse_sql_test_file()` that returns `Vec<SqlStatement>`.
+
+Update `execute_sql_script` and `compare_output` to use the new structure.
+
+Keep backward compatibility: if a `.expected` file exists alongside the `.sql` file, fall back to the old behaviour (enables incremental migration in item 51).
+
+**Commit:** Add inline expected output format to SQL test runner
+
+#### Step 50.2 — Runner: per-statement error reporting
+
+Update error messages to report the SQL statement alongside the line number so failures are immediately actionable without cross-referencing two files.
+
+**Commit:** Improve per-statement error messages in SQL test runner
+
+---
+
+## 51. Migrate Existing Tests to New Format (Track 7)
+
+### Approach
+
+Write a one-off migration script (or update `update-sql-tests` with a `--migrate` flag) that:
+1. Reads `<name>.sql` and `<name>.expected`
+2. Re-executes the SQL to pair each statement with its output
+3. Rewrites `<name>.sql` with `-- >` lines inserted after each statement
+
+Because the runner already runs the SQL to verify, this is equivalent to running `update-sql-tests` with the new writer.
+
+Migration is done test-by-test so each file can be reviewed in its own commit.
+
+### Implementation Steps (2 commits)
+
+#### Step 51.1 — Add `--migrate` flag to `update-sql-tests`
+
+When `--migrate` is passed, rewrite the `.sql` file with inline expected output instead of writing/updating a `.expected` file.
+
+**Commit:** Add --migrate flag to update-sql-tests
+
+#### Step 51.2 — Migrate all existing `.sql` files
+
+Run: `cargo run --bin update-sql-tests --migrate`
+
+Review the diff for each file. Commit the batch migration.
+
+**Commit:** Migrate all SQL tests to inline expected format
+
+---
+
+## 52. Update `update-sql-tests` to Write Inline Output (Track 7)
+
+### What Changes
+
+After migration, the `update-sql-tests` tool must write inline expected output (overwriting the `-- >` lines in the `.sql` file) rather than writing a separate `.expected` file.
+
+The tool should:
+1. Parse the `.sql` file using the new `parse_sql_test_file()`.
+2. Execute each statement.
+3. Replace each statement's `-- >` block with fresh output.
+4. Write the updated `.sql` file in place.
+
+Blank lines and `--` comments between statements are preserved unchanged.
+
+### Key Files
+
+- `src/testing/sql_runner.rs` — `update_expected_file` → `update_sql_file_inline`
+- `src/bin/update-sql-tests.rs` — no change to CLI interface
+
+### Implementation Steps (1 commit)
+
+#### Step 52.1 — Inline writer
+
+Implement `update_sql_file_inline()`:
+
+```rust
+fn update_sql_file_inline(sql_path: &PathBuf, actual_per_statement: &[Vec<String>]) {
+    // Rebuild the file, replacing -- > blocks with fresh output
+}
+```
+
+Update `run_sql_test(update_mode=true)` to call this instead of writing a separate file.
+
+**Commit:** update-sql-tests writes inline expected output
+
+---
+
+## 53. Remove Obsolete `.expected` Files (Track 7)
+
+Once all tests have been migrated and the runner no longer reads `.expected` files:
+
+1. Delete all `tests/sql/*.expected` files.
+2. Remove the backward-compatibility fallback from the runner.
+3. Update `CLAUDE.md` and `README.md` references.
+
+### Implementation Steps (1 commit)
+
+#### Step 53.1 — Delete `.expected` files and remove fallback
+
+```bash
+rm tests/sql/*.expected
+```
+
+Remove the `.expected` fallback path from `sql_runner.rs`.
+
+Update `CLAUDE.md`:
+- Change `cargo run --bin update-sql-tests` description to reflect inline format.
+- Remove references to `.expected` files.
+
+**Commit:** Remove .expected files, runner reads inline format only
+
+---
+
+## Verification
+
+For each item:
+- [ ] `cargo test test_sql_` — all SQL tests pass
+- [ ] `cargo run --bin update-sql-tests` — rewrites inline output correctly; `git diff` shows only whitespace/value changes, no structural diff
+- [ ] Zero warnings: `cargo fmt && cargo build 2>&1 | grep -i warning`
+
+**End-to-end check:**
+```bash
+# Mutate a test file to produce wrong output, then regenerate
+cargo run --bin update-sql-tests where_clauses
+git diff tests/sql/where_clauses.sql   # should show only the corrected -- > lines
+cargo test test_sql_where_clauses      # should pass
+```
+
+---
+
+## Example: Before and After
+
+**Before (two files):**
+
+`tests/sql/where_clauses.sql`:
+```sql
+CREATE TABLE numbers (id INTEGER, value INTEGER, name TEXT)
+INSERT INTO numbers VALUES (1, 100, 'one')
+INSERT INTO numbers VALUES (2, 200, 'two')
+SELECT id, value FROM numbers WHERE value=100
+SELECT id, value FROM numbers WHERE value!=100
+```
+
+`tests/sql/where_clauses.expected`:
+```
+Table 'numbers' created
+1
+1
+1	100
+3	100
+2	200
+4	300
+5	150
+```
+
+**After (single file):**
+
+`tests/sql/where_clauses.sql`:
+```sql
+CREATE TABLE numbers (id INTEGER, value INTEGER, name TEXT)
+-- > Table 'numbers' created
+
+INSERT INTO numbers VALUES (1, 100, 'one')
+-- > 1
+INSERT INTO numbers VALUES (2, 200, 'two')
+-- > 1
+
+SELECT id, value FROM numbers WHERE value=100
+-- > 1	100
+-- > 3	100
+
+SELECT id, value FROM numbers WHERE value!=100
+-- > 2	200
+-- > 4	300
+-- > 5	150
+```


### PR DESCRIPTION
## Summary

- Adds **Phase K** plan (`doc/plan/phase-k-inline-sql-tests.md`): merge `.expected` files into their corresponding `.sql` files using `-- >` comment lines, so input and expected output live together in one reviewable file
- Updates `doc/plan/README.md` with the new phase row
- Adds **`new-plan` skill** (`.claude/skills/new-plan/SKILL.md`): a Claude Code skill that gathers context from the existing roadmap, prompts the user for the feature description, writes a new phase plan file in the established format, updates the README, and opens a PR

## Phase K items

| # | Item |
|---|------|
| 50 | New `.sql` format with `-- >` inline expected output; update runner to parse it |
| 51 | Migrate all existing test files via a `--migrate` flag |
| 52 | Update `update-sql-tests` to write back inline (no separate `.expected` file) |
| 53 | Delete all `.expected` files and remove fallback |

## Test plan

- [ ] Invoke `/new-plan` skill and verify it reads existing phases, asks for input, creates a well-formed plan file, and opens a PR
- [ ] When Phase K is implemented: `cargo test test_sql_` passes with no `.expected` files present
- [ ] `cargo run --bin update-sql-tests` rewrites inline `-- >` blocks correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)