### PR TITLE
Phase G4: Advanced Indexing

### DIFF
--- a/doc/plan/README.md
+++ b/doc/plan/README.md
@@ -40,6 +40,7 @@ Fill unit test gaps (Cell/CellReader have 0 tests, Pager has 2), build automated
 | **E** | Query power | 4 | [phase-e-query-power.md](completed/phase-e-query-power.md) | Completed |
 | **F** | Serialization overhaul | 4 | [phase-f-serialization.md](completed/phase-f-serialization.md) | Completed |
 | **G** | Advanced capabilities | 8 | [phase-g-advanced.md](phase-g-advanced.md) | In Progress |
+| **G4** | Advanced Indexing | 8 | [phase-g4-advanced-indexing.md](completed/phase-g4-advanced-indexing.md) | Completed |
 | **G2** | Performance & Testing | 4 | [phase-g2-indexing-and-perf.md](completed/phase-g2-indexing-and-perf.md) | Completed |
 | **H** | Compiler Type Safety | 1 | [phase-h-compiler-safety.md](completed/phase-h-compiler-safety.md) | Completed |
 | **I** | Bug Fixes | 4 | [phase-i-bug-fixes.md](completed/phase-i-bug-fixes.md) | Completed |

--- a/doc/plan/completed/phase-g4-advanced-indexing.md
+++ b/doc/plan/completed/phase-g4-advanced-indexing.md
@@ -4,11 +4,7 @@ Builds on phase-g3-indexing.md to add multi-column indexes, TEXT support, range 
 
 ## Items
 
-| # | Track | Item | Depends on |
-|---|-------|------|------------|
-| 42 | 4.6 | Multi-column indexes | 47 |
-| 43 | 4.7 | TEXT column indexes | 47 |
-| 44 | 4.8 | Type conversions and NULL handling | — |
+(all completed)
 
 ---
 Important: Each item should be committed separately, follow 'Git Workflow' in CLAUDE.md
@@ -24,6 +20,9 @@ Important: Each item should be committed separately, follow 'Git Workflow' in CL
 | 45 | 3.7 | Remove rowid from index entry value | 2026-02-22 |
 | 46 | 5 | Engine: ReadCurrentKey + blob ops | 2026-02-22 |
 | 47 | 4.9 | Split IndexScan into IndexScan + RowidLookup | 2026-02-22 |
+| 42 | 4.6 | Multi-column indexes | 2026-02-22 |
+| 43 | 4.7 | TEXT column indexes | 2026-02-22 |
+| 44 | 4.8 | Type conversions and NULL handling | 2026-02-22 |
 
 ---
 

--- a/src/compiler/emitter.rs
+++ b/src/compiler/emitter.rs
@@ -173,6 +173,7 @@ impl BytecodeEmitter {
                 | Operation::BlobPrefixLt(_, _, _)
                 | Operation::BlobPrefixLe(_, _, _)
                 | Operation::BlobSliceTail(_, _, _)
+                | Operation::BlobSliceLast(_, _, _)
                 | Operation::DecodeU64Key(_, _)
                 // Control flow operations (without jump targets)
                 | Operation::Yield(_)

--- a/src/compiler/emitter.rs
+++ b/src/compiler/emitter.rs
@@ -174,6 +174,7 @@ impl BytecodeEmitter {
                 | Operation::BlobPrefixLe(_, _, _)
                 | Operation::BlobSliceTail(_, _, _)
                 | Operation::BlobSliceLast(_, _, _)
+                | Operation::BlobDropLast(_, _, _)
                 | Operation::DecodeU64Key(_, _)
                 // Control flow operations (without jump targets)
                 | Operation::Yield(_)

--- a/src/compiler/nodes.rs
+++ b/src/compiler/nodes.rs
@@ -442,22 +442,6 @@ pub fn codegen_filter(
     }
 }
 
-/// Generate bytecode for a Project node.
-///
-/// Project transforms input tuples by computing new expressions.
-/// Each output column is the result of evaluating a PlanExpr.
-///
-/// ```text
-/// // Child's on_tuple wired to PROJECT_COMPUTE
-/// // Child's on_done wired to parent's on_done (propagate)
-///
-/// BODY (body_emitter):
-///   PROJECT_COMPUTE: for each expr: compile_expr into output_regs[i]
-///                    GoTo(on_tuple)
-///
-/// next_label = child.next_label  // delegate to child
-/// output_regs = newly allocated registers
-/// ```
 /// Generate bytecode for an IndexScan node.
 ///
 /// Scans the index B-tree and yields one rowid per matching entry.
@@ -494,7 +478,10 @@ pub fn codegen_index_scan(
             MoveOperation::Find(lower_key_reg),
         ));
 
-        // If exclusive lower bound, skip entries where key prefix == lower bound
+        // If exclusive lower bound, skip entries where key starts with the lower bound prefix.
+        // TEXT values in encode_index_value are NUL-terminated ([0x03][bytes][0x00]), ensuring
+        // that 'a' encoded as [0x03,0x61,0x00] is NOT a prefix of 'apple' [0x03,0x61,0x70,...].
+        // So BlobStartsWith correctly identifies exact column-value matches.
         if !_lower_inclusive {
             let skip_check = ctx.body_emitter.create_label();
             ctx.body_emitter.bind_label(skip_check);
@@ -644,6 +631,22 @@ pub fn codegen_rowid_lookup(
     }
 }
 
+/// Generate bytecode for a Project node.
+///
+/// Project transforms input tuples by computing new expressions.
+/// Each output column is the result of evaluating a PlanExpr.
+///
+/// ```text
+/// // Child's on_tuple wired to PROJECT_COMPUTE
+/// // Child's on_done wired to parent's on_done (propagate)
+///
+/// BODY (body_emitter):
+///   PROJECT_COMPUTE: for each expr: compile_expr into output_regs[i]
+///                    GoTo(on_tuple)
+///
+/// next_label = child.next_label  // delegate to child
+/// output_regs = newly allocated registers
+/// ```
 pub fn codegen_project(
     columns: &[PlanExpr],
     input: &LogicalPlan,

--- a/src/compiler/nodes.rs
+++ b/src/compiler/nodes.rs
@@ -576,10 +576,10 @@ pub fn codegen_index_scan(
             .emit_goto_if_false(cont.on_done, in_range_reg);
     }
 
-    // Extract rowid from last 8 bytes of the index key
+    // Extract rowid from last 8 bytes of the index key (rowid is always the last 8 bytes)
     let pk_blob_reg = ctx.registers.alloc();
     ctx.body_emitter
-        .emit(Operation::BlobSliceTail(pk_blob_reg, key_blob_reg, 8));
+        .emit(Operation::BlobSliceLast(pk_blob_reg, key_blob_reg, 8));
     ctx.body_emitter
         .emit(Operation::DecodeU64Key(pk_reg, pk_blob_reg));
 
@@ -1188,12 +1188,16 @@ pub fn codegen_insert(
     // Write to each index
     for (i, index) in indexes.iter().enumerate() {
         let index_cursor = index_cursor_regs[i];
-        let indexed_column_reg = reordered_regs[index.column_idx];
+        let col_value_regs: Vec<_> = index
+            .column_idxs
+            .iter()
+            .map(|&col_idx| reordered_regs[col_idx])
+            .collect();
 
         ctx.body_emitter.emit(Operation::WriteIndex(
             index_cursor,
-            indexed_column_reg, // Column value to index
-            key_reg,            // Primary key (table key)
+            col_value_regs, // Column values to index (multi-column)
+            key_reg,        // Primary key (table key)
         ));
     }
 
@@ -1644,7 +1648,7 @@ pub fn codegen_delete(
 pub fn codegen_populate_index(
     input: &LogicalPlan,
     index_rootpage: u32,
-    column_idx: usize,
+    column_idxs: &[usize],
     cont: &NodeContinuation,
     ctx: &mut CodegenContext,
 ) -> NodeOutput {
@@ -1664,13 +1668,16 @@ pub fn codegen_populate_index(
     // Compile the child (expected: Scan with with_key=true).
     // output_regs = [col_0, ..., col_N-1, pk_key]
     let scan_out = codegen(input, &child_cont, ctx);
-    let col_reg = scan_out.output_regs[column_idx];
+    let col_regs: Vec<_> = column_idxs
+        .iter()
+        .map(|&idx| scan_out.output_regs[idx])
+        .collect();
     let pk_reg = *scan_out.output_regs.last().expect("key reg");
 
     // child_on_tuple: write one index entry, then advance to next row
     ctx.body_emitter.bind_label(child_on_tuple);
     ctx.body_emitter
-        .emit(Operation::WriteIndex(index_cursor, col_reg, pk_reg));
+        .emit(Operation::WriteIndex(index_cursor, col_regs, pk_reg));
     ctx.body_emitter.emit_goto(scan_out.next);
 
     // child_on_done: all rows consumed, jump to cont.on_done (no rows yielded)
@@ -1745,8 +1752,8 @@ pub fn codegen(
         LogicalPlan::PopulateIndex {
             input,
             index_rootpage,
-            column_idx,
-        } => codegen_populate_index(input, *index_rootpage, *column_idx, cont, ctx),
+            column_idxs,
+        } => codegen_populate_index(input, *index_rootpage, column_idxs, cont, ctx),
     }
 }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -151,28 +151,32 @@ pub fn execute(sql: &str, btree: &mut BTree) -> Result<ExecuteResult, ExecuteErr
                 }
             };
 
-            // 4. Find column and verify it's INTEGER (only INTEGER indexes are supported)
-            let column_def = create_table
-                .columns
-                .iter()
-                .find(|col| col.name == ci.column_name)
-                .ok_or_else(|| ExecuteError::ColumnNotFound {
-                    table: ci.table_name.clone(),
-                    column: ci.column_name.clone(),
-                })?;
+            // 4. Find columns and verify each is INTEGER (only INTEGER indexes are supported)
+            let mut column_idxs = Vec::new();
+            for col_name in &ci.column_names {
+                let column_def = create_table
+                    .columns
+                    .iter()
+                    .find(|col| &col.name == col_name)
+                    .ok_or_else(|| ExecuteError::ColumnNotFound {
+                        table: ci.table_name.clone(),
+                        column: col_name.clone(),
+                    })?;
 
-            if !matches!(column_def.type_name, Some(DataType::Integer)) {
-                return Err(ExecuteError::ColumnNotInteger {
-                    table: ci.table_name.clone(),
-                    column: ci.column_name.clone(),
-                });
+                if !matches!(column_def.type_name, Some(DataType::Integer)) {
+                    return Err(ExecuteError::ColumnNotInteger {
+                        table: ci.table_name.clone(),
+                        column: col_name.clone(),
+                    });
+                }
+
+                let col_idx = create_table
+                    .columns
+                    .iter()
+                    .position(|col| &col.name == col_name)
+                    .unwrap();
+                column_idxs.push(col_idx);
             }
-
-            let column_idx = create_table
-                .columns
-                .iter()
-                .position(|col| col.name == ci.column_name)
-                .unwrap();
 
             // 5. Create the index B-tree
             let index_rootpage = btree.create_tree();
@@ -185,7 +189,7 @@ pub fn execute(sql: &str, btree: &mut BTree) -> Result<ExecuteResult, ExecuteErr
                     with_key: true,
                 }),
                 index_rootpage,
-                column_idx,
+                column_idxs,
             };
             let compiled = compiler::compile(&plan);
             Engine::with_program(

--- a/src/db.rs
+++ b/src/db.rs
@@ -151,7 +151,7 @@ pub fn execute(sql: &str, btree: &mut BTree) -> Result<ExecuteResult, ExecuteErr
                 }
             };
 
-            // 4. Find columns and verify each is INTEGER (only INTEGER indexes are supported)
+            // 4. Find columns and verify each is INTEGER or TEXT
             let mut column_idxs = Vec::new();
             for col_name in &ci.column_names {
                 let column_def = create_table
@@ -163,7 +163,10 @@ pub fn execute(sql: &str, btree: &mut BTree) -> Result<ExecuteResult, ExecuteErr
                         column: col_name.clone(),
                     })?;
 
-                if !matches!(column_def.type_name, Some(DataType::Integer)) {
+                if !matches!(
+                    column_def.type_name,
+                    Some(DataType::Integer) | Some(DataType::Text)
+                ) {
                     return Err(ExecuteError::ColumnNotInteger {
                         table: ci.table_name.clone(),
                         column: col_name.clone(),

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -609,11 +609,7 @@ impl Engine {
             }
             EncodeIndexKey(dest, src) => {
                 let value = self.registers.get(src).scalar().unwrap();
-                let encoded_key = match value {
-                    ScalarValue::Integer(i) => storage::encode_integer_key(*i),
-                    ScalarValue::Null => vec![0; 8], // NULL sorts first
-                    _ => panic!("EncodeIndexKey: only INTEGER and NULL are supported"),
-                };
+                let encoded_key = storage::encode_index_value(value);
                 *self.registers.get_mut(dest) =
                     RegisterValue::ScalarValue(ScalarValue::Blob(encoded_key));
             }
@@ -671,6 +667,15 @@ impl Engine {
                 let tail = blob[offset..].to_vec();
                 *self.registers.get_mut(dest) = RegisterValue::ScalarValue(ScalarValue::Blob(tail));
             }
+            BlobSliceLast(dest, blob_reg, n) => {
+                let blob = match self.registers.get(blob_reg).scalar().unwrap() {
+                    ScalarValue::Blob(b) => b.clone(),
+                    _ => panic!("BlobSliceLast: blob register must be Blob"),
+                };
+                let start = blob.len().saturating_sub(n);
+                let tail = blob[start..].to_vec();
+                *self.registers.get_mut(dest) = RegisterValue::ScalarValue(ScalarValue::Blob(tail));
+            }
             DecodeU64Key(dest, blob_reg) => {
                 let blob = match self.registers.get(blob_reg).scalar().unwrap() {
                     ScalarValue::Blob(b) => b.clone(),
@@ -722,14 +727,13 @@ impl Engine {
                 let mut cursor = cursor.open_readwrite();
                 cursor.insert_u64(key, bytes);
             }
-            WriteIndex(cursor_reg, value_reg, pk_reg) => {
-                // Encode the indexed value
-                let indexed_value = self.registers.get(value_reg).scalar().unwrap();
-                let mut index_key = match indexed_value {
-                    ScalarValue::Integer(i) => storage::encode_integer_key(*i),
-                    ScalarValue::Null => vec![0; 8], // NULL sorts first
-                    _ => panic!("WriteIndex: only INTEGER and NULL column values are supported"),
-                };
+            WriteIndex(cursor_reg, value_regs, pk_reg) => {
+                // Encode each indexed column value, concatenated in order
+                let mut index_key = Vec::new();
+                for value_reg in value_regs {
+                    let indexed_value = self.registers.get(value_reg).scalar().unwrap();
+                    index_key.extend_from_slice(&storage::encode_index_value(indexed_value));
+                }
 
                 // Append primary key to make the entry unique in the index B-tree
                 let pk_value = self.registers.get(pk_reg).scalar().unwrap();

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -676,6 +676,15 @@ impl Engine {
                 let tail = blob[start..].to_vec();
                 *self.registers.get_mut(dest) = RegisterValue::ScalarValue(ScalarValue::Blob(tail));
             }
+            BlobDropLast(dest, blob_reg, n) => {
+                let blob = match self.registers.get(blob_reg).scalar().unwrap() {
+                    ScalarValue::Blob(b) => b.clone(),
+                    _ => panic!("BlobDropLast: blob register must be Blob"),
+                };
+                let end = blob.len().saturating_sub(n);
+                let head = blob[..end].to_vec();
+                *self.registers.get_mut(dest) = RegisterValue::ScalarValue(ScalarValue::Blob(head));
+            }
             DecodeU64Key(dest, blob_reg) => {
                 let blob = match self.registers.get(blob_reg).scalar().unwrap() {
                     ScalarValue::Blob(b) => b.clone(),

--- a/src/engine/program.rs
+++ b/src/engine/program.rs
@@ -164,6 +164,7 @@ pub enum Operation {
     BlobPrefixLe(Reg, Reg, Reg),   // BlobPrefixLe(dest, blob, bound): blob[..len(bound)] <= bound
     BlobSliceTail(Reg, Reg, usize), // BlobSliceTail(dest, blob, offset): blob[offset..]
     BlobSliceLast(Reg, Reg, usize), // BlobSliceLast(dest, blob, n): last n bytes of blob
+    BlobDropLast(Reg, Reg, usize), // BlobDropLast(dest, blob, n): blob without last n bytes
     DecodeU64Key(Reg, Reg),        // DecodeU64Key(dest, blob): 8-byte blob → u64 as Integer
 
     // Control Flow
@@ -483,6 +484,16 @@ impl std::fmt::Display for Operation {
                     f,
                     "{:10} {}, {}, {}",
                     "BlobLast".cyan().bold(),
+                    dest,
+                    blob,
+                    n
+                )
+            }
+            BlobDropLast(dest, blob, n) => {
+                write!(
+                    f,
+                    "{:10} {}, {}, {}",
+                    "BlobDrop".cyan().bold(),
                     dest,
                     blob,
                     n

--- a/src/engine/program.rs
+++ b/src/engine/program.rs
@@ -151,7 +151,7 @@ pub enum Operation {
     ReadCursor(Vec<Reg>, Reg), // ReadCursor(dest_regs, cursor): read row values
     ReadKey(Reg, Reg),         // ReadKey(dest, cursor): read btree key as integer
     WriteCursor(Reg, Reg, Vec<Reg>), // WriteCursor(cursor, key, values): insert row
-    WriteIndex(Reg, Reg, Reg), // WriteIndex(cursor, value, pk): insert into index
+    WriteIndex(Reg, Vec<Reg>, Reg), // WriteIndex(cursor, col_values, pk): insert into index
     DeleteCursor(Reg),         // DeleteCursor(cursor): delete row at current cursor position
     CanReadCursor(Reg, Reg),   // Reg = CanReadCursor(Reg)
     EncodeIndexKey(Reg, Reg),  // EncodeIndexKey(dest, src): scalar to sortable index blob
@@ -160,10 +160,11 @@ pub enum Operation {
 
     // Blob operations (for composing index key comparisons)
     BlobStartsWith(Reg, Reg, Reg), // BlobStartsWith(dest, blob, prefix): blob starts_with prefix
-    BlobPrefixLt(Reg, Reg, Reg),  // BlobPrefixLt(dest, blob, bound): blob[..len(bound)] < bound
-    BlobPrefixLe(Reg, Reg, Reg),  // BlobPrefixLe(dest, blob, bound): blob[..len(bound)] <= bound
+    BlobPrefixLt(Reg, Reg, Reg),   // BlobPrefixLt(dest, blob, bound): blob[..len(bound)] < bound
+    BlobPrefixLe(Reg, Reg, Reg),   // BlobPrefixLe(dest, blob, bound): blob[..len(bound)] <= bound
     BlobSliceTail(Reg, Reg, usize), // BlobSliceTail(dest, blob, offset): blob[offset..]
-    DecodeU64Key(Reg, Reg),         // DecodeU64Key(dest, blob): 8-byte blob → u64 as Integer
+    BlobSliceLast(Reg, Reg, usize), // BlobSliceLast(dest, blob, n): last n bytes of blob
+    DecodeU64Key(Reg, Reg),        // DecodeU64Key(dest, blob): 8-byte blob → u64 as Integer
 
     // Control Flow
     Yield(Vec<Reg>),
@@ -414,13 +415,14 @@ impl std::fmt::Display for Operation {
                     regs_str.join(", ")
                 )
             }
-            WriteIndex(cursor, val, pk) => {
+            WriteIndex(cursor, vals, pk) => {
+                let vals_str: Vec<String> = vals.iter().map(|r| format!("{}", r)).collect();
                 write!(
                     f,
-                    "{:10} {}, {}, {}",
+                    "{:10} {}, [{}], {}",
                     "WriteIdx".cyan().bold(),
                     cursor,
-                    val,
+                    vals_str.join(", "),
                     pk
                 )
             }
@@ -474,6 +476,16 @@ impl std::fmt::Display for Operation {
                     dest,
                     blob,
                     offset
+                )
+            }
+            BlobSliceLast(dest, blob, n) => {
+                write!(
+                    f,
+                    "{:10} {}, {}, {}",
+                    "BlobLast".cyan().bold(),
+                    dest,
+                    blob,
+                    n
                 )
             }
             DecodeU64Key(dest, blob) => {

--- a/src/frontend/ast.rs
+++ b/src/frontend/ast.rs
@@ -13,7 +13,7 @@ pub enum Statement {
 pub struct CreateIndexStatement {
     pub index_name: String,
     pub table_name: String,
-    pub column_name: String,
+    pub column_names: Vec<String>,
 }
 
 #[derive(Debug)]

--- a/src/frontend/parser.rs
+++ b/src/frontend/parser.rs
@@ -369,19 +369,23 @@ impl Parser {
     }
 
     fn parse_create_index_statement(&mut self) -> ParseResult<ast::CreateIndexStatement> {
-        // CREATE INDEX idx_name ON table_name(column_name)
+        // CREATE INDEX idx_name ON table_name(col1, col2, ...)
         // (CREATE already consumed by caller)
         self.input.expect(Expect::Index)?;
         let index_name = self.parse_identifier()?;
         self.input.expect(Expect::On)?;
         let table_name = self.parse_identifier()?;
         self.input.expect(Expect::LeftParen)?;
-        let column_name = self.parse_identifier()?;
+        let mut column_names = vec![self.parse_identifier()?];
+        while let lexer::Type::Comma = self.input.peek() {
+            self.input.advance();
+            column_names.push(self.parse_identifier()?);
+        }
         self.input.expect(Expect::RightParen)?;
         Ok(ast::CreateIndexStatement {
             index_name,
             table_name,
-            column_name,
+            column_names,
         })
     }
 
@@ -1232,7 +1236,21 @@ mod test {
             ast::Statement::CreateIndex(ci) => {
                 assert_eq!(ci.index_name, "idx_age");
                 assert_eq!(ci.table_name, "users");
-                assert_eq!(ci.column_name, "age");
+                assert_eq!(ci.column_names, vec!["age"]);
+            }
+            _ => panic!("Expected CreateIndex statement"),
+        }
+    }
+
+    #[test]
+    fn test_parse_create_index_multi_column() {
+        let sql = "CREATE INDEX idx_name_age ON users(last_name, first_name, age)";
+        let stmt = parse(sql).unwrap();
+        match stmt {
+            ast::Statement::CreateIndex(ci) => {
+                assert_eq!(ci.index_name, "idx_name_age");
+                assert_eq!(ci.table_name, "users");
+                assert_eq!(ci.column_names, vec!["last_name", "first_name", "age"]);
             }
             _ => panic!("Expected CreateIndex statement"),
         }

--- a/src/planner.rs
+++ b/src/planner.rs
@@ -916,6 +916,13 @@ fn try_plan_index_scan(
         if let Some((col, lit)) = extract_equality_filter(filter) {
             // Equality: col = X → [X, X] inclusive on both sides
             (col, Some((lit.clone(), true)), Some((lit, true)))
+        } else if let Some(col) = extract_is_null_filter(filter) {
+            // IS NULL: use Null literal as both bounds
+            (
+                col,
+                Some((Literal::Null, true)),
+                Some((Literal::Null, true)),
+            )
         } else {
             extract_range_filter(filter)?
         };
@@ -997,6 +1004,16 @@ fn extract_single_range(
             let lit = extract_literal(rhs)?;
             Some((col, None, Some((lit, true))))
         }
+        _ => None,
+    }
+}
+
+fn extract_is_null_filter(expr: &ast::Expression) -> Option<String> {
+    match expr {
+        ast::Expression::UnaryOp {
+            op: ast::UnaryOp::IsNull,
+            expression,
+        } => extract_column_name(expression),
         _ => None,
     }
 }

--- a/src/planner.rs
+++ b/src/planner.rs
@@ -77,7 +77,7 @@ pub struct SortKey {
 #[derive(Debug, Clone, PartialEq)]
 pub struct IndexMaintenanceInfo {
     pub rootpage: u32,
-    pub column_idx: usize,
+    pub column_idxs: Vec<usize>,
 }
 
 /// Aggregate function types
@@ -250,13 +250,13 @@ pub enum LogicalPlan {
     Distinct { input: Box<LogicalPlan> },
 
     /// Populate an index B-tree from an existing table.
-    /// Scans all rows in the table, encoding each row's indexed column and
+    /// Scans all rows in the table, encoding each row's indexed columns and
     /// primary key as a composite index key, then writes to the index B-tree.
     /// Output: no rows (yields immediately to on_done).
     PopulateIndex {
         input: Box<LogicalPlan>,
         index_rootpage: u32,
-        column_idx: usize,
+        column_idxs: Vec<usize>,
     },
 }
 // ============================================================================
@@ -877,16 +877,22 @@ fn plan_insert(insert: ast::InsertStatement, btree: &BTree) -> Result<LogicalPla
     let index_infos = btree.lookup_indexes_for_table(&insert.table_name);
     let mut indexes = Vec::new();
     for index_info in index_infos {
-        // Find column index
-        let col_idx = table
-            .columns
+        // Find column indexes
+        let column_idxs = index_info
+            .column_names
             .iter()
-            .position(|col| col.name == index_info.column_name)
-            .expect("Index column not found in table");
+            .map(|name| {
+                table
+                    .columns
+                    .iter()
+                    .position(|col| &col.name == name)
+                    .expect("Index column not found in table")
+            })
+            .collect();
 
         indexes.push(IndexMaintenanceInfo {
             rootpage: index_info.rootpage,
-            column_idx: col_idx,
+            column_idxs,
         });
     }
 
@@ -915,7 +921,10 @@ fn try_plan_index_scan(
         };
 
     let indexes = btree.lookup_indexes_for_table(table_name);
-    let index = indexes.iter().find(|idx| idx.column_name == col_name)?;
+    // Find an index whose first column matches col_name (prefix matching)
+    let index = indexes
+        .iter()
+        .find(|idx| idx.column_names.first().map(|s| s.as_str()) == Some(col_name.as_str()))?;
 
     Some(LogicalPlan::RowidLookup {
         input: Box::new(LogicalPlan::IndexScan {
@@ -3054,6 +3063,85 @@ mod tests {
             },
             _ => panic!("Expected Project, got {:?}", p),
         }
+    }
+
+    #[test]
+    fn test_plan_multi_column_index_uses_first_column() {
+        use super::{plan, Literal, LogicalPlan};
+        use crate::test::TestDb;
+
+        let test = TestDb::default();
+        let mut btree = test.btree;
+
+        let sql_table = "CREATE TABLE events (id INTEGER, year INTEGER, month INTEGER)";
+        let root = btree.create_tree();
+        btree.insert_schema_entry("table", "events", "events", root, sql_table);
+
+        // Multi-column index on (year, month)
+        let sql_index = "CREATE INDEX idx_year_month ON events(year, month)";
+        let index_root = btree.create_tree();
+        btree.insert_schema_entry("index", "idx_year_month", "events", index_root, sql_index);
+
+        // Query on first column should use the index
+        let stmt = parse_sql("SELECT id FROM events WHERE year = 2024");
+        let plan = plan(stmt, &btree).expect("Planning failed");
+
+        match plan {
+            LogicalPlan::Project { input, .. } => match *input {
+                LogicalPlan::RowidLookup { input, .. } => match *input {
+                    LogicalPlan::IndexScan {
+                        index_rootpage,
+                        lower_bound,
+                        upper_bound,
+                    } => {
+                        assert_eq!(index_rootpage, index_root);
+                        assert_eq!(lower_bound, Some((Literal::Integer(2024), true)));
+                        assert_eq!(upper_bound, Some((Literal::Integer(2024), true)));
+                    }
+                    _ => panic!("Expected IndexScan, got {:?}", input),
+                },
+                _ => panic!("Expected RowidLookup, got {:?}", input),
+            },
+            _ => panic!("Expected Project, got {:?}", plan),
+        }
+    }
+
+    #[test]
+    fn test_plan_multi_column_index_not_used_for_non_first_column() {
+        use super::{plan, LogicalPlan};
+        use crate::test::TestDb;
+
+        let test = TestDb::default();
+        let mut btree = test.btree;
+
+        let sql_table = "CREATE TABLE events (id INTEGER, year INTEGER, month INTEGER)";
+        let root = btree.create_tree();
+        btree.insert_schema_entry("table", "events", "events", root, sql_table);
+
+        // Multi-column index on (year, month) - only second column referenced
+        let sql_index = "CREATE INDEX idx_year_month ON events(year, month)";
+        let index_root = btree.create_tree();
+        btree.insert_schema_entry("index", "idx_year_month", "events", index_root, sql_index);
+
+        // Query on second column should NOT use the index (falls back to table scan)
+        let stmt = parse_sql("SELECT id FROM events WHERE month = 6");
+        let plan = plan(stmt, &btree).expect("Planning failed");
+
+        // Should NOT contain IndexScan (uses table scan + filter instead)
+        fn contains_index_scan(p: &LogicalPlan) -> bool {
+            matches!(p, LogicalPlan::IndexScan { .. })
+                || match p {
+                    LogicalPlan::Project { input, .. } => contains_index_scan(input),
+                    LogicalPlan::Filter { input, .. } => contains_index_scan(input),
+                    LogicalPlan::RowidLookup { input, .. } => contains_index_scan(input),
+                    _ => false,
+                }
+        }
+        assert!(
+            !contains_index_scan(&plan),
+            "Should not use index for non-first column: {:?}",
+            plan
+        );
     }
 
     #[test]

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -13,6 +13,7 @@ mod btree_verify;
 
 pub use btree::decode_integer_key;
 pub use btree::decode_u64_key;
+pub use btree::encode_index_value;
 pub use btree::encode_integer_key;
 pub use btree::encode_u64_key;
 pub use btree::BTree;

--- a/src/storage/btree.rs
+++ b/src/storage/btree.rs
@@ -1114,6 +1114,9 @@ pub fn decode_u64_key(bytes: &[u8]) -> u64 {
 /// Encode a single index column value as sortable bytes with a type tag prefix.
 ///
 /// Type tags ensure cross-type ordering: NULL(0x00) < INTEGER(0x01) < REAL(0x02) < TEXT(0x03).
+/// TEXT values are NUL-terminated ([0x03][utf8_bytes][0x00]) so that shorter strings are not
+/// byte-level prefixes of longer strings. This ensures BlobStartsWith can reliably detect
+/// exact column-value equality (e.g. 'a' is not a prefix of 'apple' after NUL termination).
 /// The returned bytes are concatenated with other column encodings to form the full index key.
 pub fn encode_index_value(value: &crate::engine::scalarvalue::ScalarValue) -> Vec<u8> {
     use crate::engine::scalarvalue::ScalarValue;
@@ -1137,8 +1140,10 @@ pub fn encode_index_value(value: &crate::engine::scalarvalue::ScalarValue) -> Ve
             key
         }
         ScalarValue::String(s) => {
+            // NUL-terminated: ensures 'a' ([0x03,0x61,0x00]) is not a prefix of 'apple'
             let mut key = vec![0x03];
             key.extend_from_slice(s.as_bytes());
+            key.push(0x00); // NUL terminator
             key
         }
         _ => panic!("encode_index_value: unsupported type {:?}", value),

--- a/src/storage/btree.rs
+++ b/src/storage/btree.rs
@@ -49,7 +49,7 @@ impl CursorState {}
 #[derive(Debug, Clone)]
 pub struct IndexInfo {
     pub index_name: String,
-    pub column_name: String,
+    pub column_names: Vec<String>,
     pub rootpage: u32,
 }
 
@@ -861,11 +861,11 @@ impl BTree {
                             let name = values[1].as_str().unwrap_or("").to_string();
                             let rootpage = values[3].as_u64().unwrap() as u32;
                             let sql = values[4].as_str().unwrap_or("");
-                            let column_name = extract_column_from_index_sql(sql);
+                            let column_names = extract_columns_from_index_sql(sql);
 
                             indexes.push(IndexInfo {
                                 index_name: name,
-                                column_name,
+                                column_names,
                                 rootpage,
                             });
                         }
@@ -1111,15 +1111,42 @@ pub fn decode_u64_key(bytes: &[u8]) -> u64 {
     u64::from_be_bytes(bytes.try_into().unwrap())
 }
 
+/// Encode a single index column value as sortable bytes with a type tag prefix.
+///
+/// Type tags ensure cross-type ordering: NULL(0x00) < INTEGER(0x01) < TEXT(0x03).
+/// The returned bytes are concatenated with other column encodings to form the full index key.
+pub fn encode_index_value(value: &crate::engine::scalarvalue::ScalarValue) -> Vec<u8> {
+    use crate::engine::scalarvalue::ScalarValue;
+    match value {
+        ScalarValue::Null => vec![0x00],
+        ScalarValue::Integer(i) => {
+            let mut key = vec![0x01];
+            key.extend_from_slice(&encode_integer_key(*i));
+            key
+        }
+        ScalarValue::String(s) => {
+            let mut key = vec![0x03];
+            key.extend_from_slice(s.as_bytes());
+            key
+        }
+        _ => panic!("encode_index_value: unsupported type {:?}", value),
+    }
+}
+
 /// Extract column name from a CREATE INDEX SQL string.
 /// "CREATE INDEX idx ON table(col)" → "col"
-fn extract_column_from_index_sql(sql: &str) -> String {
+fn extract_columns_from_index_sql(sql: &str) -> Vec<String> {
     if let Some(start) = sql.find('(') {
         if let Some(end) = sql[start..].find(')') {
-            return sql[start + 1..start + end].trim().to_string();
+            let inside = &sql[start + 1..start + end];
+            return inside
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect();
         }
     }
-    String::new()
+    vec![]
 }
 
 #[cfg(test)]
@@ -1537,7 +1564,7 @@ mod test {
         let indexes = btree.lookup_indexes_for_table("users");
         assert_eq!(indexes.len(), 1);
         assert_eq!(indexes[0].index_name, "idx_age");
-        assert_eq!(indexes[0].column_name, "age");
+        assert_eq!(indexes[0].column_names, vec!["age"]);
         assert_eq!(indexes[0].rootpage, index_root);
     }
 

--- a/src/storage/btree.rs
+++ b/src/storage/btree.rs
@@ -1113,7 +1113,7 @@ pub fn decode_u64_key(bytes: &[u8]) -> u64 {
 
 /// Encode a single index column value as sortable bytes with a type tag prefix.
 ///
-/// Type tags ensure cross-type ordering: NULL(0x00) < INTEGER(0x01) < TEXT(0x03).
+/// Type tags ensure cross-type ordering: NULL(0x00) < INTEGER(0x01) < REAL(0x02) < TEXT(0x03).
 /// The returned bytes are concatenated with other column encodings to form the full index key.
 pub fn encode_index_value(value: &crate::engine::scalarvalue::ScalarValue) -> Vec<u8> {
     use crate::engine::scalarvalue::ScalarValue;
@@ -1122,6 +1122,18 @@ pub fn encode_index_value(value: &crate::engine::scalarvalue::ScalarValue) -> Ve
         ScalarValue::Integer(i) => {
             let mut key = vec![0x01];
             key.extend_from_slice(&encode_integer_key(*i));
+            key
+        }
+        ScalarValue::Floating(f) => {
+            // IEEE 754 sortable encoding: flip sign bit (and all bits if negative)
+            let bits = f.to_bits();
+            let sortable = if bits >> 63 == 0 {
+                bits ^ 0x8000_0000_0000_0000
+            } else {
+                bits ^ 0xFFFF_FFFF_FFFF_FFFF
+            };
+            let mut key = vec![0x02];
+            key.extend_from_slice(&sortable.to_be_bytes());
             key
         }
         ScalarValue::String(s) => {

--- a/tests/sql/index_multi_column.sql
+++ b/tests/sql/index_multi_column.sql
@@ -1,0 +1,23 @@
+CREATE TABLE users (id INTEGER, last TEXT, first TEXT, age INTEGER)
+-- > Table 'users' created
+INSERT INTO users VALUES (1, 'Smith', 'Alice', 30)
+-- > 1
+INSERT INTO users VALUES (2, 'Smith', 'Bob', 25)
+-- > 1
+INSERT INTO users VALUES (3, 'Jones', 'Charlie', 30)
+-- > 1
+INSERT INTO users VALUES (4, 'Adams', 'Diana', 25)
+-- > 1
+CREATE INDEX idx_age_id ON users(age, id)
+-- > Index 'idx_age_id' created
+-- Use index via first column equality (prefix match)
+SELECT id FROM users WHERE age = 30 ORDER BY id
+-- > 1
+-- > 3
+SELECT id FROM users WHERE age = 25 ORDER BY id
+-- > 2
+-- > 4
+-- Range scan on first column of multi-column index
+SELECT id FROM users WHERE age > 25 ORDER BY id
+-- > 1
+-- > 3

--- a/tests/sql/index_null_handling.sql
+++ b/tests/sql/index_null_handling.sql
@@ -1,0 +1,27 @@
+CREATE TABLE data (id INTEGER, value INTEGER)
+-- > Table 'data' created
+CREATE INDEX idx_value ON data(value)
+-- > Index 'idx_value' created
+INSERT INTO data VALUES (1, NULL)
+-- > 1
+INSERT INTO data VALUES (2, 10)
+-- > 1
+INSERT INTO data VALUES (3, 20)
+-- > 1
+INSERT INTO data VALUES (4, NULL)
+-- > 1
+-- NULL values appear in index, IS NULL uses index
+SELECT id FROM data WHERE value IS NULL ORDER BY id
+-- > 1
+-- > 4
+-- Non-null values still work
+SELECT id FROM data WHERE value = 10
+-- > 2
+SELECT id FROM data WHERE value > 10
+-- > 3
+-- NULL sorts before all other values in index
+SELECT id FROM data ORDER BY value
+-- > 1
+-- > 4
+-- > 2
+-- > 3

--- a/tests/sql/index_text.sql
+++ b/tests/sql/index_text.sql
@@ -30,3 +30,17 @@ INSERT INTO products VALUES (5, 'apricot', 120)
 -- > 1
 SELECT id FROM products WHERE name = 'apricot'
 -- > 5
+-- Bug regression: 'a' is not a prefix of 'apple', so WHERE name > 'a' should include 'apple'
+SELECT id FROM products WHERE name > 'a' ORDER BY id
+-- > 1
+-- > 2
+-- > 3
+-- > 4
+-- > 5
+-- Similarly, WHERE name > 'ap' should include 'apple' and 'apricot' (and all others)
+SELECT id FROM products WHERE name > 'ap' ORDER BY id
+-- > 1
+-- > 2
+-- > 3
+-- > 4
+-- > 5

--- a/tests/sql/index_text.sql
+++ b/tests/sql/index_text.sql
@@ -1,0 +1,32 @@
+CREATE TABLE products (id INTEGER, name TEXT, price INTEGER)
+-- > Table 'products' created
+INSERT INTO products VALUES (1, 'apple', 100)
+-- > 1
+INSERT INTO products VALUES (2, 'banana', 150)
+-- > 1
+INSERT INTO products VALUES (3, 'cherry', 200)
+-- > 1
+INSERT INTO products VALUES (4, 'date', 250)
+-- > 1
+CREATE INDEX idx_name ON products(name)
+-- > Index 'idx_name' created
+-- Equality scan on TEXT index
+SELECT id FROM products WHERE name = 'banana'
+-- > 2
+SELECT id FROM products WHERE name = 'cherry'
+-- > 3
+-- No match
+SELECT id FROM products WHERE name = 'elderberry'
+-- > OK
+-- Range scan on TEXT index
+SELECT id FROM products WHERE name > 'banana' ORDER BY id
+-- > 3
+-- > 4
+SELECT id FROM products WHERE name < 'cherry' ORDER BY id
+-- > 1
+-- > 2
+-- INSERT after index creation
+INSERT INTO products VALUES (5, 'apricot', 120)
+-- > 1
+SELECT id FROM products WHERE name = 'apricot'
+-- > 5


### PR DESCRIPTION
## Summary

- **Item 42**: Multi-column indexes — `CREATE INDEX idx ON t(a, b)` now supported; composite keys encoded as concatenated column values + rowid
- **Item 43**: TEXT column indexes — index scans work on TEXT columns with range and equality filters
- **Item 44**: NULL handling and IS NULL optimization — `WHERE col IS NULL` uses index scan when applicable; REAL type support in index key encoding

## Bug fix

- Fixed TEXT range scan bug where `WHERE name > 'a'` incorrectly skipped 'apple'. Root cause: encoded 'a' (`[0x03,0x61]`) was a byte prefix of 'apple' (`[0x03,0x61,0x70,...]`), triggering the exclusive lower bound skip. Fix: NUL-terminate TEXT encodings so 'a' becomes `[0x03,0x61,0x00]`, which is not a prefix of 'apple'.

## Test plan

- [ ] `cargo test` — all tests pass
- [ ] `cargo test test_sql_index` — index SQL tests pass (multi-column, text, null handling, regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)