### PR TITLE
Plan: Phases AG, AH, AI — Workspace split and colored decoupling

### DIFF
--- a/doc/plan/README.md
+++ b/doc/plan/README.md
@@ -67,6 +67,7 @@ Fill unit test gaps (Cell/CellReader have 0 tests, Pager has 2), build automated
 | **AD** | Page-Geometry-Aware Overflow Thresholds | 4 | [phase-ad-overflow-thresholds.md](completed/phase-ad-overflow-thresholds.md) | Completed |
 | **AE** | TUI Bytecode Debugger | 3 | [phase-ae-tui-debugger.md](completed/phase-ae-tui-debugger.md) | Completed |
 | **AF** | Covering Indexes | 3 | [phase-af-covering-indexes.md](completed/phase-af-covering-indexes.md) | Completed |
+| **AG** | Workspace Split: Core Library + CLI Crate | 4 | [phase-ag-workspace-split.md](phase-ag-workspace-split.md) | Planned |
 
 ## Future
 

--- a/doc/plan/README.md
+++ b/doc/plan/README.md
@@ -68,6 +68,7 @@ Fill unit test gaps (Cell/CellReader have 0 tests, Pager has 2), build automated
 | **AE** | TUI Bytecode Debugger | 3 | [phase-ae-tui-debugger.md](completed/phase-ae-tui-debugger.md) | Completed |
 | **AF** | Covering Indexes | 3 | [phase-af-covering-indexes.md](completed/phase-af-covering-indexes.md) | Completed |
 | **AG** | Workspace Split: Core Library + CLI Crate | 4 | [phase-ag-workspace-split.md](phase-ag-workspace-split.md) | Planned |
+| **AH** | Decouple `colored` from Core Library | 4 | [phase-ah-decouple-colored.md](phase-ah-decouple-colored.md) | Planned |
 
 ## Future
 

--- a/doc/plan/README.md
+++ b/doc/plan/README.md
@@ -69,6 +69,7 @@ Fill unit test gaps (Cell/CellReader have 0 tests, Pager has 2), build automated
 | **AF** | Covering Indexes | 3 | [phase-af-covering-indexes.md](completed/phase-af-covering-indexes.md) | Completed |
 | **AG** | Workspace Split: Core Library + CLI Crate | 4 | [phase-ag-workspace-split.md](phase-ag-workspace-split.md) | Planned |
 | **AH** | Decouple `colored` from Core Library | 4 | [phase-ah-decouple-colored.md](phase-ah-decouple-colored.md) | Planned |
+| **AI** | Move `inspect_page` to CLI | 2 | [phase-ai-inspect-to-cli.md](phase-ai-inspect-to-cli.md) | Planned |
 
 ## Future
 

--- a/doc/plan/phase-ag-workspace-split.md
+++ b/doc/plan/phase-ag-workspace-split.md
@@ -1,0 +1,317 @@
+# Phase AG — Workspace Split: Core Library + CLI Crate
+
+Restructure the single-crate repository into a Cargo workspace with a standalone
+`database` library crate and a separate `database-cli` crate for the REPL and
+interactive tooling.
+
+## Items
+
+| # | Track | Item | Depends on |
+|---|-------|------|------------|
+| 119 | 6 | Convert root Cargo.toml to workspace root and create `crates/database-cli/` skeleton | — |
+| 120 | 6 | Move `src/main.rs` + `src/repl/` into `crates/database-cli/` | 119 |
+| 121 | 6 | Move REPL/TUI deps to CLI crate; promote test deps to `[dev-dependencies]` | 120 |
+| 122 | 7 | Update CLAUDE.md and README.md for workspace layout | 121 |
+
+---
+Important: Each item should be committed separately, follow 'Git Workflow' in CLAUDE.md
+
+---
+
+## Overview
+
+The entire codebase lives in one Cargo package today.  A user who wants to embed
+the database engine in their application would pull in `rustyline`, `ratatui`,
+`crossterm`, and `ansi-to-tui` — none of which they need.  Similarly, `proptest`,
+`rand`, and `tempfile` are test-only but listed as normal dependencies.
+
+Splitting into a Cargo workspace fixes both problems:
+
+- **`crates/database`** — the core library.  Zero interactive / TUI deps.  This is
+  what an application author adds to their `Cargo.toml`.
+- **`crates/database-cli`** — the interactive REPL and TUI debugger.  Depends on
+  `database` and brings in UI deps.
+
+The `tests/` directory, `build.rs`, and the `update-sql-tests` binary all belong to
+the library crate (they test and support the engine, not the REPL).
+
+**Embedding example after this phase:**
+
+```toml
+# application Cargo.toml
+[dependencies]
+database = { path = "../database/crates/database" }
+# or once published:
+# database = "0.1"
+```
+
+```rust
+use database::db::Db;
+
+fn main() {
+    let mut db = Db::open("app.db").unwrap();
+    db.execute("CREATE TABLE IF NOT EXISTS kv (key TEXT, value TEXT)").unwrap();
+    db.execute("INSERT INTO kv VALUES ('hello', 'world')").unwrap();
+    let rows = db.query("SELECT key, value FROM kv").unwrap();
+    println!("{:?}", rows);
+}
+```
+
+---
+
+## 119. Convert root to workspace + create CLI skeleton (Track 6)
+
+### What Changes
+
+1. Add a `[workspace]` section to the **root** `Cargo.toml` listing two members:
+   - `.` (the existing `database` library package — stays at root)
+   - `crates/database-cli`
+2. Create `crates/database-cli/Cargo.toml` with:
+   - `name = "database-cli"`
+   - A dependency on `database = { path = "../.." }` (the root library)
+   - An empty `src/main.rs` (`fn main() {}`) as a placeholder
+3. Remove `default-run = "database"` from root `Cargo.toml` (no longer needed once
+   the binary is gone from the root package).
+
+After this commit `cargo build --workspace` compiles cleanly.  The existing
+`database` binary still lives in the root package at this point.
+
+### Background
+
+A Cargo workspace allows multiple packages in one repository.  The root
+`Cargo.toml` gains:
+
+```toml
+[workspace]
+members = [".", "crates/database-cli"]
+resolver = "2"
+```
+
+The root package (`[package]` block) stays unchanged — it is still the `database`
+library crate.  Workspace membership is additive.
+
+### Implementation Approach
+
+Root `Cargo.toml` additions:
+
+```toml
+[workspace]
+members = [".", "crates/database-cli"]
+resolver = "2"
+```
+
+`crates/database-cli/Cargo.toml` (initial skeleton):
+
+```toml
+[package]
+name = "database-cli"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+database = { path = "../.." }
+```
+
+`crates/database-cli/src/main.rs` (placeholder):
+
+```rust
+fn main() {}
+```
+
+### Key Files
+
+- `Cargo.toml` — add `[workspace]` section, remove `default-run`
+- `crates/database-cli/Cargo.toml` — new file
+- `crates/database-cli/src/main.rs` — placeholder
+
+### Tests
+
+```bash
+cargo build --workspace
+cargo test --workspace  # all existing tests still pass
+```
+
+### Implementation Steps (1 commit)
+
+#### Step 119.1 — Add workspace Cargo.toml and CLI skeleton
+
+**Commit:** `Refactor: convert to Cargo workspace, add database-cli skeleton`
+
+---
+
+## 120. Move `src/main.rs` + `src/repl/` into `crates/database-cli/` (Track 6)
+
+### What Changes
+
+1. Copy `src/main.rs` → `crates/database-cli/src/main.rs` (replacing the placeholder),
+   updating the `use database::...` paths (they already use the crate name, so most
+   will work unchanged).
+2. Move `src/repl/` → `crates/database-cli/src/repl/`.
+3. Remove `src/main.rs` and `src/repl/` from the root package.
+4. Remove `mod repl;` from what was the binary entry point (now gone from root).
+5. The root package `Cargo.toml` no longer has a `[[bin]]` target for `database`;
+   the CLI binary is now `database-cli`.
+
+After this commit:
+- `cargo run -p database-cli -- test.db` launches the REPL.
+- `cargo test` (library tests) still passes.
+
+### Background
+
+`src/main.rs` today does:
+
+```rust
+mod repl;
+
+use database::storage;
+use repl::{Repl, SharedState};
+```
+
+The `mod repl;` resolves to `src/repl/mod.rs`.  After the move this becomes
+`crates/database-cli/src/repl/mod.rs` and `mod repl;` in
+`crates/database-cli/src/main.rs` resolves correctly.
+
+The REPL modes reference library types via `use database::...` paths — these
+already use the published crate name and require no changes.  The few
+`use super::...` or `use crate::...` paths inside `src/repl/` will need updating
+to `use database::...` where they reference library internals.
+
+### Key Files
+
+- `crates/database-cli/src/main.rs` — moved from `src/main.rs`
+- `crates/database-cli/src/repl/` — moved from `src/repl/`
+- `src/main.rs` — deleted
+- `src/repl/` — deleted
+
+### Tests
+
+```bash
+cargo build --workspace             # no errors
+cargo run -p database-cli -- test.db sql "SELECT 1"
+cargo test                          # library tests pass
+```
+
+### Implementation Steps (1 commit)
+
+#### Step 120.1 — Move REPL source files to crates/database-cli/
+
+**Commit:** `Refactor: move REPL and main.rs into crates/database-cli`
+
+---
+
+## 121. Move REPL/TUI deps to CLI; promote test deps to dev-dependencies (Track 6)
+
+### What Changes
+
+Move these deps from the **root** `Cargo.toml` to `crates/database-cli/Cargo.toml`:
+
+| Dep | Reason |
+|-----|--------|
+| `rustyline` | REPL readline library |
+| `ratatui` | TUI framework (used only in `tui_debugger.rs`) |
+| `crossterm` | Terminal backend for ratatui |
+| `ansi-to-tui` | ANSI escape → ratatui widget (used in TUI debugger) |
+
+Move these to `[dev-dependencies]` in the root `Cargo.toml`:
+
+| Dep | Reason |
+|-----|--------|
+| `proptest` | Property-based tests (`src/storage/btree.rs`, etc.) |
+| `rand` | Random data generation in tests |
+| `tempfile` | Temporary file creation in tests |
+
+`colored` stays in the root library (`[dependencies]`) — it is used in
+`src/storage/btree.rs`, `src/engine/program.rs`, and `src/engine/scalarvalue.rs`
+for debug/display formatting.
+
+`serde`, `serde_bytes`, `ciborium`, `peekmore` stay as normal library deps.
+
+### Implementation Approach
+
+Root `Cargo.toml` after changes:
+
+```toml
+[dependencies]
+ciborium       = { version = "0.2", default-features = false, features = ["std"] }
+colored        = "2"
+peekmore       = "1.3.0"
+serde          = { version = "1.0.158", features = ["derive"] }
+serde_bytes    = "0.11"
+
+[dev-dependencies]
+proptest       = "1.1.0"
+rand           = "0.8.5"
+tempfile       = "3.24.0"
+```
+
+`crates/database-cli/Cargo.toml` after changes:
+
+```toml
+[dependencies]
+database       = { path = "../.." }
+ansi-to-tui    = "7"
+colored        = "2"
+crossterm      = "0.28"
+ratatui        = "0.29"
+rustyline      = "17.0.2"
+```
+
+### Key Files
+
+- `Cargo.toml` — trim `[dependencies]`, add `[dev-dependencies]`
+- `crates/database-cli/Cargo.toml` — add REPL/TUI deps
+
+### Tests
+
+```bash
+cargo build --workspace
+cargo test --workspace   # proptest, rand, tempfile available via dev-deps
+```
+
+### Implementation Steps (1 commit)
+
+#### Step 121.1 — Redistribute dependencies between library and CLI crates
+
+**Commit:** `Refactor: move REPL/TUI deps to CLI crate, test deps to dev-dependencies`
+
+---
+
+## 122. Update CLAUDE.md and README.md for workspace layout (Track 7)
+
+### What Changes
+
+Update documentation to reflect:
+
+1. **CLAUDE.md**: Update build commands to use `--workspace` or `-p` flags where
+   relevant; update the architecture section to describe the two-crate structure;
+   update the interactive CLI section to use `cargo run -p database-cli`.
+2. **README.md**: Add an "Embedding" section showing how to depend on `database`
+   from an application; update the "Running" / "Usage" section for the new binary
+   name/path.
+
+### Key Files
+
+- `CLAUDE.md`
+- `README.md`
+
+### Tests
+
+n/a — documentation only.
+
+### Implementation Steps (1 commit)
+
+#### Step 122.1 — Update CLAUDE.md and README.md for workspace
+
+**Commit:** `Docs: update CLAUDE.md and README for Cargo workspace layout`
+
+---
+
+## Verification
+
+- [ ] `cargo build --workspace` — clean build, zero errors
+- [ ] `cargo test --workspace` — all tests pass, no regressions
+- [ ] `cargo fmt --all && cargo build --workspace 2>&1 | grep -i warning` — zero warnings
+- [ ] `cargo run -p database-cli -- test.db` launches the interactive REPL
+- [ ] `cargo run -p database-cli -- test.db sql "SELECT 1"` returns `1`
+- [ ] A project that adds `database = { path = "..." }` compiles without pulling in `rustyline`, `ratatui`, `crossterm`, or `ansi-to-tui`
+- [ ] Each commit is independently buildable

--- a/doc/plan/phase-ah-decouple-colored.md
+++ b/doc/plan/phase-ah-decouple-colored.md
@@ -1,0 +1,365 @@
+# Phase AH — Decouple `colored` from Core Library
+
+Remove the `colored` dependency from the `database` library crate by making all
+`Display` implementations plain text and moving colored formatting into newtype
+wrappers in `crates/database-cli`.
+
+## Items
+
+| # | Track | Item | Depends on |
+|---|-------|------|------------|
+| 123 | 6 | Plain `ScalarValue::Display`; `ColoredScalarValue` wrapper in CLI | Phase AG |
+| 124 | 6 | Plain `Reg`, `JumpTarget`, `Operation::Display`; colored wrappers in CLI; update engine mode and TUI debugger | 123 |
+| 125 | 6 | Remove `colored` from `btree.rs` inspect output | 124 |
+| 126 | 6 | Drop `colored` from library `Cargo.toml`; verify clean build | 125 |
+
+---
+Important: Each item should be committed separately, follow 'Git Workflow' in CLAUDE.md
+
+---
+
+## Overview
+
+After Phase AG, the `database` library crate still depends on `colored` because
+three core files use it for terminal output:
+
+| File | Usage |
+|------|-------|
+| `src/engine/scalarvalue.rs` | `ScalarValue::Display` — colorizes integers, strings, etc. |
+| `src/engine/program.rs` | `Display` for `Reg`, `JumpTarget`, `Operation` — colorized bytecode listing |
+| `src/storage/btree.rs` | `inspect`/`print_page` diagnostic output — coloured page dump |
+
+An application that embeds `database` does not need terminal color output at all.
+Colors are a presentation concern and belong in the CLI layer.
+
+**The approach**: make every `Display` impl in the library produce plain text.
+Add a `crates/database-cli/src/display.rs` module with newtype wrappers that
+re-implement the colored formatting for the REPL and TUI debugger.
+
+```
+Before:  format!("{op}")              → ANSI-colored string from library Display
+After:   format!("{op}")              → plain text
+         format!("{}", ColoredOp(op)) → ANSI-colored string from CLI wrapper
+```
+
+The TUI debugger uses `ansi-to-tui` to convert ANSI strings to ratatui widgets.
+After this phase it continues to work: it calls `format!("{}", ColoredOp(op))`
+instead of `format!("{op}")`, producing the same ANSI output.
+
+---
+
+## 123. Plain `ScalarValue::Display`; `ColoredScalarValue` wrapper in CLI (Track 6)
+
+### What Changes
+
+1. **`src/engine/scalarvalue.rs`**: Remove `use colored::Colorize;` from the
+   `Display` impl.  Make it plain text:
+
+   ```rust
+   // Before
+   ScalarValue::Integer(i)  => write!(f, "{}", i.to_string().green()),
+   ScalarValue::String(s)   => write!(f, "{}", format!("\"{}\"", s).green()),
+   ScalarValue::Floating(f) => write!(f, "{}", fl.to_string().green()),
+   ScalarValue::Boolean(b)  => write!(f, "{}", b.to_string().green()),
+   ScalarValue::Blob(b)     => write!(f, "{}", format!("Blob({})", b.len()).green()),
+   ScalarValue::Null        => write!(f, "NULL"),
+
+   // After
+   ScalarValue::Integer(i)  => write!(f, "{i}"),
+   ScalarValue::String(s)   => write!(f, "\"{s}\""),
+   ScalarValue::Floating(fl)=> write!(f, "{fl}"),
+   ScalarValue::Boolean(b)  => write!(f, "{b}"),
+   ScalarValue::Blob(b)     => write!(f, "Blob({})", b.len()),
+   ScalarValue::Null        => write!(f, "NULL"),
+   ```
+
+2. **`crates/database-cli/src/display.rs`** (new file): Add `ColoredScalarValue`
+   wrapper with the original colored formatting:
+
+   ```rust
+   use colored::Colorize as _;
+   use database::engine::scalarvalue::ScalarValue;
+   use std::fmt;
+
+   pub struct ColoredScalarValue<'a>(pub &'a ScalarValue);
+
+   impl fmt::Display for ColoredScalarValue<'_> {
+       fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+           use ScalarValue::*;
+           match self.0 {
+               Integer(i)  => write!(f, "{}", i.to_string().green()),
+               Floating(fl)=> write!(f, "{}", fl.to_string().green()),
+               Boolean(b)  => write!(f, "{}", b.to_string().green()),
+               String(s)   => write!(f, "{}", format!("\"{}\"", s).green()),
+               Blob(b)     => write!(f, "{}", format!("Blob({})", b.len()).green()),
+               Null        => write!(f, "NULL"),
+           }
+       }
+   }
+   ```
+
+3. Update usages in `crates/database-cli/src/repl/modes/engine.rs` and
+   `crates/database-cli/src/repl/tui_debugger.rs` to use `ColoredScalarValue(&v)`
+   wherever `format!("{v}")` was emitting colored scalar output.
+
+   In `tui_debugger.rs` the register pane (around line 294) does:
+   ```rust
+   // Before
+   RegisterValue::ScalarValue(s) => format!("  r{i} = {s}"),
+   // After
+   RegisterValue::ScalarValue(s) => format!("  r{i} = {}", ColoredScalarValue(s)),
+   ```
+
+   In `engine.rs` mode (around line 67 and 177):
+   ```rust
+   // Before
+   RegisterValue::ScalarValue(s) => format!("{s}"),
+   // After
+   RegisterValue::ScalarValue(s) => format!("{}", ColoredScalarValue(s)),
+   ```
+
+### Key Files
+
+- `src/engine/scalarvalue.rs` — plain Display
+- `crates/database-cli/src/display.rs` — new, `ColoredScalarValue`
+- `crates/database-cli/src/repl/modes/engine.rs` — use wrapper
+- `crates/database-cli/src/repl/tui_debugger.rs` — use wrapper
+- `crates/database-cli/src/main.rs` (or `lib.rs`) — `mod display;`
+
+### Tests
+
+```bash
+cargo build --workspace
+cargo test --workspace
+# Verify scalar values still print correctly in REPL and TUI
+cargo run -p database-cli -- test.db sql "SELECT 1, 'hello', 3.14"
+```
+
+### Implementation Steps (1 commit)
+
+#### Step 123.1 — Plain ScalarValue Display; ColoredScalarValue in CLI
+
+**Commit:** `Refactor: plain ScalarValue::Display, move colored formatting to CLI wrapper`
+
+---
+
+## 124. Plain `Reg`, `JumpTarget`, `Operation::Display`; colored wrappers; update REPL and TUI (Track 6)
+
+### What Changes
+
+1. **`src/engine/program.rs`**: Remove `use colored::Colorize;` from all three
+   `Display` impls and strip color calls:
+
+   ```rust
+   // Reg — Before
+   write!(f, "{}", format!("R{}", self.0).yellow())
+   // After
+   write!(f, "R{}", self.0)
+
+   // JumpTarget — Before
+   JumpTarget::Resolved(addr) => write!(f, "{}", format!("@{}", addr).magenta()),
+   JumpTarget::Unresolved(label) => write!(f, "{}", format!("?L{}", label.0).red()),
+   // After
+   JumpTarget::Resolved(addr) => write!(f, "@{addr}"),
+   JumpTarget::Unresolved(label) => write!(f, "?L{}", label.0),
+
+   // Operation — Before (example)
+   StoreValue(r, v) => write!(f, "{:10} {}, {}", "Store".cyan().bold(), r, v),
+   // After
+   StoreValue(r, v) => write!(f, "{:10} {}, {}", "Store", r, v),
+   ```
+
+   All color calls in the `Operation::Display` match arm are removed — leave the
+   mnemonic strings and structure intact, just without `.cyan().bold()` etc.
+
+2. **`crates/database-cli/src/display.rs`**: Add `ColoredReg`, `ColoredJumpTarget`,
+   `ColoredOperation` wrappers that mirror the colored formatting:
+
+   ```rust
+   pub struct ColoredReg(pub Reg);
+   impl fmt::Display for ColoredReg {
+       fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+           write!(f, "{}", format!("R{}", self.0.0).yellow())
+       }
+   }
+
+   pub struct ColoredJumpTarget<'a>(pub &'a JumpTarget);
+   impl fmt::Display for ColoredJumpTarget<'_> {
+       fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+           match self.0 {
+               JumpTarget::Resolved(addr) =>
+                   write!(f, "{}", format!("@{addr}").magenta()),
+               JumpTarget::Unresolved(label) =>
+                   write!(f, "{}", format!("?L{}", label.0).red()),
+           }
+       }
+   }
+
+   pub struct ColoredOperation<'a>(pub &'a Operation);
+   impl fmt::Display for ColoredOperation<'_> {
+       fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+           use Operation::*;
+           match self.0 {
+               StoreValue(r, v) =>
+                   write!(f, "{:10} {}, {}", "Store".cyan().bold(),
+                          ColoredReg(*r), v),
+               // ... one arm per Operation variant, mirroring program.rs ...
+           }
+       }
+   }
+   ```
+
+   `ColoredOperation` internally uses `ColoredReg` and `ColoredJumpTarget` so that
+   registers and jump targets within an instruction listing are still coloured.
+
+3. **Update CLI usages**:
+
+   In `crates/database-cli/src/repl/modes/engine.rs`:
+   ```rust
+   // Before (program listing)
+   output += &format!("{}  {}\n", format!("{:4}", i).dimmed(), op);
+   // After
+   output += &format!("{}  {}\n", format!("{:4}", i).dimmed(), ColoredOperation(op));
+
+   // Before (step output)
+   .map(|o| format!("{o}"))
+   // After
+   .map(|o| format!("{}", ColoredOperation(o)))
+   ```
+
+   In `crates/database-cli/src/repl/tui_debugger.rs`:
+   ```rust
+   // Before (program pane, line ~264)
+   let ansi_str = format!("{prefix}{i:4}  {op}");
+   // After
+   let ansi_str = format!("{prefix}{i:4}  {}", ColoredOperation(op));
+   ```
+
+   The `ansi_str.into_text()` call on the next line continues to work unchanged
+   because `ColoredOperation` still emits ANSI escape codes via `colored`.
+
+### Key Files
+
+- `src/engine/program.rs` — plain Display for `Reg`, `JumpTarget`, `Operation`
+- `crates/database-cli/src/display.rs` — add `ColoredReg`, `ColoredJumpTarget`, `ColoredOperation`
+- `crates/database-cli/src/repl/modes/engine.rs` — use wrappers
+- `crates/database-cli/src/repl/tui_debugger.rs` — use wrappers
+
+### Tests
+
+```bash
+cargo build --workspace
+cargo test --workspace
+# REPL engine mode should still show colored bytecode
+cargo run -p database-cli -- test.db engine compile "SELECT 1"
+cargo run -p database-cli -- test.db engine program
+# TUI debugger should still show colored register and program panes
+cargo run -p database-cli -- test.db  # then: enter engine, compile ..., tui
+```
+
+### Implementation Steps (1 commit)
+
+#### Step 124.1 — Plain program.rs Display; colored wrappers; update engine mode and TUI
+
+**Commit:** `Refactor: plain Operation/Reg/JumpTarget Display, move colored formatting to CLI wrappers`
+
+---
+
+## 125. Remove `colored` from `btree.rs` inspect output (Track 6)
+
+### What Changes
+
+**`src/storage/btree.rs`**: The `print_page` / inspect method contains ~30 lines
+of `println!` calls using `colored`.  Replace all color calls with plain text:
+
+```rust
+// Before
+println!("{}: {}", "Type".yellow(), "ZeroPage".green());
+println!("    {}={}", "key".cyan(), key_hex);
+println!("    {}={}", "continuation".cyan(), "None".bright_black());
+
+// After
+println!("Type: ZeroPage");
+println!("    key={key_hex}");
+println!("    continuation=None");
+```
+
+Remove `use colored::Colorize;` from `btree.rs`.
+
+**Note**: The inspect functionality lives entirely within `BTree` as a method, not
+in the REPL layer.  Moving it to the CLI is a worthwhile long-term goal (it's a
+diagnostic tool, not a library concern) but is out of scope for this phase.  Plain
+text output is a sufficient improvement for now.
+
+### Key Files
+
+- `src/storage/btree.rs` — remove colored, plain `println!`
+
+### Tests
+
+```bash
+cargo build --workspace
+cargo run -p database-cli -- test.db btree inspect page 0
+cargo run -p database-cli -- test.db btree inspect all
+```
+
+Output should still be readable; just no ANSI colours.
+
+### Implementation Steps (1 commit)
+
+#### Step 125.1 — Remove colored from btree.rs inspect output
+
+**Commit:** `Refactor: remove colored from btree inspect — plain text output`
+
+---
+
+## 126. Drop `colored` from library `Cargo.toml`; verify clean build (Track 6)
+
+### What Changes
+
+**`Cargo.toml`** (library root): Remove the `colored` line from `[dependencies]`.
+
+```toml
+# Remove:
+colored = "2"
+```
+
+`colored` remains in `crates/database-cli/Cargo.toml` — it was already added
+there in Phase AG (Item 121).
+
+After this change, `cargo build -p database` (library only) must succeed with
+zero warnings and without pulling in any terminal-color dependency.
+
+### Key Files
+
+- `Cargo.toml` — remove `colored`
+
+### Tests
+
+```bash
+cargo build -p database           # library only — must succeed
+cargo build --workspace           # both crates
+cargo test --workspace            # all tests pass
+# Confirm no colored dep in library build graph:
+cargo tree -p database | grep colored  # should print nothing
+```
+
+### Implementation Steps (1 commit)
+
+#### Step 126.1 — Remove colored from library Cargo.toml
+
+**Commit:** `Refactor: remove colored dependency from database library crate`
+
+---
+
+## Verification
+
+- [ ] `cargo build -p database` — zero errors, zero warnings
+- [ ] `cargo tree -p database | grep colored` — empty (no colored in library graph)
+- [ ] `cargo build --workspace` — clean
+- [ ] `cargo test --workspace` — all tests pass, no regressions
+- [ ] `cargo fmt --all && cargo build --workspace 2>&1 | grep -i warning` — zero warnings
+- [ ] REPL engine mode shows colored bytecode listing (`compile <sql>` + `program`)
+- [ ] TUI debugger shows colored program and register panes
+- [ ] `btree inspect page 0` output is readable plain text
+- [ ] Each commit is independently buildable

--- a/doc/plan/phase-ai-inspect-to-cli.md
+++ b/doc/plan/phase-ai-inspect-to-cli.md
@@ -1,0 +1,189 @@
+# Phase AI — Move `inspect_page` to CLI
+
+Move the `BTree::inspect_page` diagnostic method out of the library and into the
+btree REPL mode in `crates/database-cli`, eliminating the only use of `colored`
+in `src/storage/btree.rs` and keeping diagnostic presentation entirely in the CLI.
+
+This phase supersedes **AH item 125** ("remove colored from btree.rs inspect —
+plain text output"). If AI is completed, AH item 125 can be skipped.
+
+## Items
+
+| # | Track | Item | Depends on |
+|---|-------|------|------------|
+| 127 | 6 | Add `BTree::pager()` accessor; re-implement `inspect_page` in CLI btree REPL mode | Phase AG |
+| 128 | 6 | Remove `BTree::inspect_page` and `colored` from `src/storage/btree.rs` | 127 |
+
+---
+Important: Each item should be committed separately, follow 'Git Workflow' in CLAUDE.md
+
+---
+
+## Overview
+
+`BTree::inspect_page` is a diagnostic tool — it dumps the raw on-disk structure
+of a page for debugging serialization, overflow chains, and CBOR encoding.  It
+has no place in a library API: it calls `println!` directly and depends on
+`colored` for terminal colouring.
+
+All the types it needs are already `pub`:
+- `pager::Pager` — `get_file_size_pages()`, `get_and_decode()`
+- `pager::ZeroPage`
+- `node::NodePage`, `LeafNodePage`, `InteriorNodePage`, `OverflowPage`
+
+The only missing piece is access to `BTree`'s private `pager` field.  Adding a
+`pub fn pager(&self) -> Ref<'_, Pager>` accessor is sufficient — the CLI's btree
+REPL mode can then drive the inspection itself.
+
+```
+Before:  CLI btree mode  →  BTree::inspect_page()  →  println!(colored output)
+After:   CLI btree mode  →  BTree::pager()          →  formats + println!(colored output)
+```
+
+The behavior visible to the user (`cargo run -p database-cli -- test.db btree inspect page 0`)
+is identical.  The library is cleaner.
+
+---
+
+## 127. Add `BTree::pager()` accessor; re-implement inspect in CLI (Track 6)
+
+### What Changes
+
+**`src/storage/btree.rs`**: Add a single new public method:
+
+```rust
+use std::cell::Ref;
+use super::pager::Pager;
+
+impl BTree {
+    /// Borrow the underlying Pager for diagnostic / inspection purposes.
+    pub fn pager(&self) -> Ref<'_, Pager> {
+        self.pager.borrow()
+    }
+}
+```
+
+**`crates/database-cli/src/repl/modes/btree.rs`**: Replace the two calls to
+`shared.btree.inspect_page(page_num)` with a local `inspect_page` free function
+(or method on the btree mode state) that takes `&BTree` and does everything
+`BTree::inspect_page` currently does — including the colored output:
+
+```rust
+use colored::Colorize as _;
+use database::storage::{
+    btree::BTree,
+    node::{NodePage, OverflowPage},
+    pager::ZeroPage,
+};
+
+fn inspect_page(btree: &BTree, page_num: u32) -> Result<(), String> {
+    let pager = btree.pager();
+    let file_size = pager.get_file_size_pages();
+
+    if page_num >= file_size {
+        return Err(format!(
+            "Page {} out of range (file has {} pages)",
+            page_num, file_size
+        ));
+    }
+
+    println!(
+        "{}",
+        format!("Page {} raw CBOR structure:", page_num)
+            .bright_cyan()
+            .bold()
+    );
+    println!("{}", "=====================================".bright_black());
+
+    if page_num == 0 {
+        let zero: ZeroPage = pager.get_and_decode(0);
+        println!("{}: {}", "Type".yellow(), "ZeroPage".green());
+        println!("{:#?}", zero);
+    } else {
+        let node: NodePage = pager.get_and_decode(page_num);
+        // ... rest of the match arms, identical to current BTree::inspect_page ...
+    }
+
+    Ok(())
+}
+```
+
+The two call sites in the btree mode become:
+
+```rust
+// Before
+match shared.btree.inspect_page(page_num) { ... }
+
+// After
+match inspect_page(&shared.btree, page_num) { ... }
+```
+
+The colored output and all formatting is preserved exactly — the function body is
+copied verbatim from `BTree::inspect_page`; only the location changes.
+
+### Key Files
+
+- `src/storage/btree.rs` — add `pub fn pager(&self) -> Ref<'_, Pager>`
+- `crates/database-cli/src/repl/modes/btree.rs` — add `inspect_page` free function, update call sites
+
+### Tests
+
+```bash
+cargo build --workspace
+cargo run -p database-cli -- test.db btree inspect page 0
+cargo run -p database-cli -- test.db btree inspect all
+# Output must be identical to before
+```
+
+### Implementation Steps (1 commit)
+
+#### Step 127.1 — Add pager() accessor; move inspect_page to CLI btree mode
+
+**Commit:** `Refactor: move inspect_page to CLI btree mode, expose BTree::pager() accessor`
+
+---
+
+## 128. Remove `BTree::inspect_page` and `colored` from `btree.rs` (Track 6)
+
+### What Changes
+
+1. **`src/storage/btree.rs`**: Delete the `inspect_page` method entirely.  Remove
+   `use colored::Colorize;` from the file.
+2. Verify no other code in the library references `colored`.
+
+After this commit, `src/storage/btree.rs` has zero `colored` usage.  Combined
+with the `colored` removals from `scalarvalue.rs` and `program.rs` in Phase AH,
+the library has no `colored` dependency at all (enabling AH item 126 — dropping
+`colored` from `Cargo.toml`).
+
+### Key Files
+
+- `src/storage/btree.rs` — delete `inspect_page`, remove `use colored::Colorize`
+
+### Tests
+
+```bash
+cargo build -p database        # library builds without colored
+cargo build --workspace        # full build
+cargo test --workspace
+# btree inspect still works (CLI implementation from item 127)
+cargo run -p database-cli -- test.db btree inspect page 0
+```
+
+### Implementation Steps (1 commit)
+
+#### Step 128.1 — Delete BTree::inspect_page; remove colored from btree.rs
+
+**Commit:** `Refactor: remove BTree::inspect_page and colored from storage layer`
+
+---
+
+## Verification
+
+- [ ] `cargo build --workspace` — clean, zero warnings
+- [ ] `cargo test --workspace` — all tests pass
+- [ ] `grep -r "colored" src/` — empty (no colored in library source)
+- [ ] `cargo tree -p database | grep colored` — empty
+- [ ] `cargo run -p database-cli -- test.db btree inspect page 0` — coloured output identical to before
+- [ ] `cargo run -p database-cli -- test.db btree inspect all` — works correctly
+- [ ] Each commit is independently buildable


### PR DESCRIPTION
## Summary

- **Phase AG** — Convert to Cargo workspace: `database` library crate at root + new `crates/database-cli` for the REPL/TUI. Removes REPL/TUI deps (`rustyline`, `ratatui`, `crossterm`, `ansi-to-tui`) from the core library.
- **Phase AH** — Decouple `colored` from the core library: make `ScalarValue`, `Reg`, `JumpTarget`, `Operation` Display impls plain text; add `ColoredScalarValue`/`ColoredOperation`/etc. wrappers in the CLI crate.
- **Phase AI** — Move `inspect_page` diagnostic method out of `BTree` into the CLI btree REPL mode (exposed via a new `BTree::pager()` accessor). Supersedes AH item 125.

After all three phases, an application embedding the database only pulls in `ciborium`, `serde`, `serde_bytes`, `peekmore`, and `colored` — with `colored` also removed once AH/AI are complete.

## Dependencies

AG → AI → AH (AI supersedes AH item 125; AH item 126 drops `colored` from `Cargo.toml` once btree.rs is clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)