### PR TITLE
storage: use serde_bytes for Cell and InteriorNodePage key/value encoding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ A single-file relational database library in Rust, similar to SQLite. Implements
 ```bash
 cargo build              # Debug build
 cargo build --release    # Release build
+RUSTFLAGS="-C force-frame-pointers=yes" cargo build --release  # For perf profiling (needed for correct Rust stack frames)
 cargo test               # Run all tests (lib + integration + doctests) - THE BASELINE
 cargo test test_sql_     # Run SQL integration tests
 cargo test <test_name>   # Run single test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,6 @@ ratatui = "0.30"
 crossterm = "0.28"
 ansi-to-tui = "8"
 probe = "0.5"
+
+[profile.release]
+debug = 1

--- a/src/storage/btree.rs
+++ b/src/storage/btree.rs
@@ -111,14 +111,33 @@ const MIN_CELLS_PER_PAGE: usize = 4;
 /// Measured empirically — see `measure_cbor_framing_overhead` in node.rs (actual: 14 bytes).
 const LEAF_PAGE_BASE_FRAMING_BYTES: usize = 15;
 
-/// Conservative CBOR framing overhead per `Cell` (key bytes + struct wrapper overhead).
-/// The key is always 8 bytes (u64 rowid big-endian). Inline value bytes are added on top.
-/// Measured empirically — see `measure_cbor_framing_overhead` in node.rs (actual: 11 bytes).
-const CELL_FRAMING_BYTES: usize = 15;
+/// CBOR framing overhead per `Cell` (key bytes + all CBOR headers), excluding raw value data.
+///
+/// Measured as `cbor_size(cell) - value_len` across CBOR length-prefix tier boundaries
+/// — see `measure_cbor_framing_overhead` in node.rs. Re-tune with:
+///   cargo test measure_cbor_framing -- --nocapture
+///
+/// For data-tree row cells (the only cells whose values can overflow):
+///   keys are always 8-byte u64 rowids — key CBOR header is 1 byte (8 ≤ 23).
+///   Index-tree keys are larger but index values are always empty, so they never
+///   trigger overflow and are not subject to CHUNK_THRESHOLD.
+///
+/// Overhead breakdown (worst case: value ≥ 256 bytes):
+///   1  outer CBOR array header
+///   1  key byte-string header  (8-byte key ≤ 23, so 1-byte CBOR length prefix)
+///   8  key data bytes
+///   3  value byte-string header (value ≥ 256 bytes → 3-byte CBOR length prefix)
+///  ──
+///  13  total
+///
+/// Note: with serde_bytes the key header depends only on key LENGTH (not byte values),
+/// so high-valued key bytes no longer incur a per-byte varint penalty. Only the
+/// value length prefix still requires this tier-based accounting.
+const CELL_FRAMING_BYTES: usize = 13;
 
 /// Maximum inline value bytes stored directly in a `Cell` on a leaf page.
 /// Derived so that `MIN_CELLS_PER_PAGE` cells can always fit on one page.
-/// With PAGE_SIZE=4096: CHUNK_THRESHOLD = (4096 - 15) / 4 - 15 = 1005.
+/// With PAGE_SIZE=4096: CHUNK_THRESHOLD = (4096 - 15) / 4 - 13 = 1007.
 /// Typical SQL rows (< 500 bytes) now store inline with no overflow pages.
 const CHUNK_THRESHOLD: usize = (pager::PAGE_SIZE as usize - LEAF_PAGE_BASE_FRAMING_BYTES)
     / MIN_CELLS_PER_PAGE

--- a/src/storage/cell.rs
+++ b/src/storage/cell.rs
@@ -38,10 +38,15 @@ impl Serialize for Cell {
     where
         S: serde::Serializer,
     {
-        match self.continuation {
-            Some(continuation) => (&self.key, &self.value, continuation).serialize(serializer),
-            None => (&self.key, &self.value).serialize(serializer),
+        use serde::ser::SerializeTuple;
+        let len = if self.continuation.is_some() { 3 } else { 2 };
+        let mut tup = serializer.serialize_tuple(len)?;
+        tup.serialize_element(serde_bytes::Bytes::new(&self.key))?;
+        tup.serialize_element(serde_bytes::Bytes::new(&self.value))?;
+        if let Some(cont) = self.continuation {
+            tup.serialize_element(&cont)?;
         }
+        tup.end()
     }
 }
 
@@ -57,11 +62,11 @@ impl<'de> Visitor<'de> for CellDeserializeVisitor {
     where
         A: serde::de::SeqAccess<'de>,
     {
-        let key: Vec<u8> = seq.next_element()?.unwrap();
-        let value: Vec<u8> = seq.next_element()?.unwrap();
+        let key: serde_bytes::ByteBuf = seq.next_element()?.unwrap();
+        let value: serde_bytes::ByteBuf = seq.next_element()?.unwrap();
         let continuation = seq.next_element()?;
 
-        Ok((key, value, continuation))
+        Ok((key.into_vec(), value.into_vec(), continuation))
     }
 }
 

--- a/src/storage/node.rs
+++ b/src/storage/node.rs
@@ -560,6 +560,24 @@ mod test {
     ///
     /// Run with `cargo test measure_cbor_framing -- --nocapture` to see byte counts.
     /// These values inform the derived overflow constants in btree.rs.
+    ///
+    /// # How to re-tune the constants
+    ///
+    /// Run this test and check the printed values. For each constant in btree.rs:
+    ///
+    /// - `OVERFLOW_PAGE_FRAMING_BYTES`: must be >= `overflow_with_cont_large` + 2
+    ///   (the +2 accounts for the content byte-string header growing from 1 to 3 bytes
+    ///   when content exceeds 255 bytes; the test only measures empty content).
+    ///
+    /// - `LEAF_PAGE_BASE_FRAMING_BYTES`: must be >= `leaf_empty`.
+    ///
+    /// - `CELL_FRAMING_BYTES`: must be >= `max_data_cell_overhead` printed below.
+    ///   This is measured by sweeping value sizes across each CBOR length-prefix tier
+    ///   boundary (0, 23, 24, 255, 256 bytes). The value-header length prefix jumps at
+    ///   these boundaries (1→2→3 bytes). The key header also varies with key length,
+    ///   but data-tree keys are always 8-byte rowids (header stays 1 byte).
+    ///   Index-tree keys can be longer, but index values are always empty so they
+    ///   never trigger overflow and are not subject to CHUNK_THRESHOLD.
     #[test]
     fn measure_cbor_framing_overhead() {
         fn cbor_size<T: serde::Serialize>(v: &T) -> usize {
@@ -568,13 +586,20 @@ mod test {
             buf.len()
         }
 
+        // cell_overhead: everything in the CBOR cell except the raw value bytes.
+        // = 1 (outer array) + key_header + key_data + value_header
+        // For data-tree cells key is always 8 bytes (u64 rowid); key_header is 1 byte.
+        // value_header grows across tier boundaries: 1 byte (≤23), 2 bytes (24–255), 3 bytes (256+).
+        let cell_overhead = |key_len: usize, value_len: usize| -> usize {
+            cbor_size(&Cell::new(vec![0u8; key_len], vec![0u8; value_len], None)) - value_len
+        };
+
         let overflow_no_cont = NodePage::OverflowPage(OverflowPage::new(vec![], None));
         let overflow_with_cont_small = NodePage::OverflowPage(OverflowPage::new(vec![], Some(0)));
         // Worst-case continuation: u32::MAX encodes as 5 CBOR bytes
         let overflow_with_cont_large =
             NodePage::OverflowPage(OverflowPage::new(vec![], Some(u32::MAX)));
         let leaf_empty = NodePage::Leaf(LeafNodePage::default());
-        let cell_empty = Cell::new(vec![0u8; 8], vec![], None);
         // Measure a leaf with one empty cell to get per-cell framing overhead
         let mut leaf_one_cell = LeafNodePage::default();
         leaf_one_cell.insert_item_at_index(0, Cell::new(vec![0u8; 8], vec![], None));
@@ -585,7 +610,15 @@ mod test {
         let overflow_with_cont_large_size = cbor_size(&overflow_with_cont_large);
         let leaf_empty_size = cbor_size(&leaf_empty);
         let leaf_one_cell_size = cbor_size(&leaf_one_cell_page);
-        let cell_size = cbor_size(&cell_empty);
+
+        // Sweep value sizes across CBOR length-prefix tier boundaries for an 8-byte key.
+        // The overhead (cell_size - value_len) changes only at tier boundaries.
+        let tier_boundaries = [0usize, 23, 24, 255, 256, 65535];
+        let max_data_cell_overhead = tier_boundaries
+            .iter()
+            .map(|&v| cell_overhead(8, v))
+            .max()
+            .unwrap();
 
         println!(
             "overflow_no_cont (base framing): {} bytes",
@@ -600,35 +633,40 @@ mod test {
             overflow_with_cont_large_size
         );
         println!("leaf_empty (base leaf framing): {} bytes", leaf_empty_size);
-        println!("leaf_one_cell: {} bytes", leaf_one_cell_size);
         println!(
             "per-cell framing (leaf_one_cell - leaf_empty): {} bytes",
             leaf_one_cell_size - leaf_empty_size
         );
-        println!("cell_empty (standalone): {} bytes", cell_size);
+        println!("--- cell_overhead(key=8, value=N) at tier boundaries ---");
+        for v in tier_boundaries {
+            println!("  value={v:5}: overhead={}", cell_overhead(8, v));
+        }
+        println!(
+            "max_data_cell_overhead (key=8): {} bytes",
+            max_data_cell_overhead
+        );
 
-        // Validate the conservative upper bounds used in btree.rs constants.
-        // Each constant must be >= the measured value so the derived OVERFLOW_LIMIT and
-        // CHUNK_THRESHOLD are safe lower bounds (not over-aggressive thresholds).
+        // ── Assertions ──────────────────────────────────────────────────────────────
+        // Each constant in btree.rs must be >= the measured worst case.
 
-        // OVERFLOW_PAGE_FRAMING_BYTES = 44 must be >= worst-case framing:
-        // base (38) + content-header growth (+2 for len > 255) + u32 growth (+4 for u32::MAX)
-        // The measured value here only covers the empty-content framing; the content-header
-        // growth is accounted for separately via the +2 in the constant derivation comment.
+        // OVERFLOW_PAGE_FRAMING_BYTES = 44 must cover:
+        //   base framing with empty content + Some(u32::MAX)  →  measured here
+        //   + 2 bytes for content byte-string header growing 1→3 when content > 255 bytes
+        //     (not measured here since content is empty; accounted for in the constant)
         assert!(
-            overflow_with_cont_large_size <= 44,
-            "overflow_with_cont max-u32 framing ({overflow_with_cont_large_size}) exceeds constant OVERFLOW_PAGE_FRAMING_BYTES=44"
+            overflow_with_cont_large_size + 2 <= 44,
+            "overflow worst-case framing ({} + 2 content-header growth) exceeds OVERFLOW_PAGE_FRAMING_BYTES=44",
+            overflow_with_cont_large_size
         );
         // LEAF_PAGE_BASE_FRAMING_BYTES = 15 must be >= leaf_empty_size
         assert!(
             leaf_empty_size <= 15,
             "leaf_empty framing ({leaf_empty_size}) exceeds constant LEAF_PAGE_BASE_FRAMING_BYTES=15"
         );
-        // CELL_FRAMING_BYTES = 15 must be >= per-cell overhead (leaf_one_cell - leaf_empty)
-        let per_cell_framing = leaf_one_cell_size - leaf_empty_size;
+        // CELL_FRAMING_BYTES = 13 must be >= max overhead across all value-size tiers
         assert!(
-            per_cell_framing <= 15,
-            "per-cell framing ({per_cell_framing}) exceeds constant CELL_FRAMING_BYTES=15"
+            max_data_cell_overhead <= 13,
+            "max data-cell overhead ({max_data_cell_overhead}) exceeds constant CELL_FRAMING_BYTES=13"
         );
     }
 

--- a/src/storage/node.rs
+++ b/src/storage/node.rs
@@ -183,11 +183,60 @@ pub enum VerifyError {
     KeyOutOfOrder,
 }
 
+/// Serde module for `Vec<Vec<u8>>`: serializes each inner `Vec<u8>` as a CBOR byte string
+/// (major type 2) rather than a CBOR array of integers, matching the `serde_bytes` approach
+/// used for individual byte slices.
+mod serde_vec_bytes {
+    use serde::{
+        de::{SeqAccess, Visitor},
+        ser::SerializeSeq,
+        Deserializer, Serializer,
+    };
+
+    pub fn serialize<S>(keys: &Vec<Vec<u8>>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut seq = serializer.serialize_seq(Some(keys.len()))?;
+        for key in keys {
+            seq.serialize_element(serde_bytes::Bytes::new(key))?;
+        }
+        seq.end()
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<Vec<u8>>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct ByteVecVisitor;
+        impl<'de> Visitor<'de> for ByteVecVisitor {
+            type Value = Vec<Vec<u8>>;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("sequence of byte strings")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let mut out = Vec::with_capacity(seq.size_hint().unwrap_or(0));
+                while let Some(buf) = seq.next_element::<serde_bytes::ByteBuf>()? {
+                    out.push(buf.into_vec());
+                }
+                Ok(out)
+            }
+        }
+        deserializer.deserialize_seq(ByteVecVisitor)
+    }
+}
+
 // [edge 0] [key 0] [edge 1] [key 1] ... [key N-1] [edge N]
 // items in [edge i] are LESS than or EQUAL to [key i]
 // (if there is no [key i], i.e. at the end, items in [edge i] must be GREATER than [key i-1])
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct InteriorNodePage {
+    #[serde(with = "serde_vec_bytes")]
     keys: Vec<Key>,
     edges: Vec<u32>,
 }


### PR DESCRIPTION
## Summary

- **`Cell` key and value** were serialized as CBOR arrays of integers (one ciborium call per byte). With `serde_bytes::Bytes`/`ByteBuf` they now encode as CBOR byte strings (major type 2): one length-prefix header + raw bytes. This was the dominant hot path in perf profiling (~57% of CPU in `collect_seq` → `Title::from`).
- **`InteriorNodePage` keys** (`Vec<Vec<u8>>`) had the same issue via derived `Serialize`. Added a `serde_vec_bytes` module and `#[serde(with)]` to fix it.
- **`CELL_FRAMING_BYTES`** tightened from 15 → 13, with the derivation now backed by an experimental tier-boundary sweep in `measure_cbor_framing_overhead`. The test sweeps value sizes at 0, 23, 24, 255, 256, 65535 bytes to find where the CBOR length-prefix grows, asserts the constant is sufficient, and documents how to re-tune it.
- `CHUNK_THRESHOLD` rises from 1005 → 1007 as a result.
- `RUSTFLAGS="-C force-frame-pointers=yes"` documented in `CLAUDE.md` for future perf builds.

**Breaking change:** on-disk CBOR format for leaf and interior pages changes. Existing `.db` files are not compatible.

## Test plan

- [ ] `cargo test` passes (all 48 tests)
- [ ] `cargo test measure_cbor_framing -- --nocapture` prints tier table and shows `max_data_cell_overhead = 13`
- [ ] Re-run `make test-sakila` and compare perf profile to baseline

🤖 Generated with [Claude Code](https://claude.ai/claude-code)