### PR TITLE
engine: take &BTree in constructors; add BTree::share()

### DIFF
--- a/src/compiler/nodes.rs
+++ b/src/compiler/nodes.rs
@@ -2125,7 +2125,7 @@ mod tests {
         let (ops, num_registers) = compile_plan(&plan);
 
         // Run through engine
-        let mut engine = Engine::with_program(&ops, num_registers, btree);
+        let mut engine = Engine::with_program(&ops, num_registers, &btree);
         let yields = engine.run();
 
         // Count should yield single row with value 3
@@ -2152,7 +2152,7 @@ mod tests {
         let (ops, num_registers) = compile_plan(&plan);
 
         // Run through engine
-        let mut engine = Engine::with_program(&ops, num_registers, btree);
+        let mut engine = Engine::with_program(&ops, num_registers, &btree);
         let yields = engine.run();
 
         // Count should yield 0 for empty table
@@ -2184,7 +2184,7 @@ mod tests {
         let (ops, num_registers) = compile_plan(&plan);
 
         // Run through engine
-        let mut engine = Engine::with_program(&ops, num_registers, btree);
+        let mut engine = Engine::with_program(&ops, num_registers, &btree);
         let yields = engine.run();
 
         // Should have 2 rows
@@ -2218,7 +2218,7 @@ mod tests {
         let test = TestDb::default();
         let btree = test.btree;
 
-        let mut engine = Engine::with_program(&ops, num_registers, btree);
+        let mut engine = Engine::with_program(&ops, num_registers, &btree);
         let yields = engine.run();
 
         assert_eq!(yields.len(), 3);
@@ -2246,7 +2246,7 @@ mod tests {
         let test = TestDb::default();
         let btree = test.btree;
 
-        let mut engine = Engine::with_program(&ops, num_registers, btree);
+        let mut engine = Engine::with_program(&ops, num_registers, &btree);
         let yields = engine.run();
 
         assert_eq!(yields.len(), 0);
@@ -2272,7 +2272,7 @@ mod tests {
         let test = TestDb::default();
         let btree = test.btree;
 
-        let mut engine = Engine::with_program(&ops, num_registers, btree);
+        let mut engine = Engine::with_program(&ops, num_registers, &btree);
         let yields = engine.run();
 
         assert_eq!(yields.len(), 1);
@@ -2296,7 +2296,7 @@ mod tests {
         let test = TestDb::default();
         let btree = test.btree;
 
-        let mut engine = Engine::with_program(&ops, num_registers, btree);
+        let mut engine = Engine::with_program(&ops, num_registers, &btree);
         let yields = engine.run();
 
         assert_eq!(yields.len(), 1);
@@ -2320,7 +2320,7 @@ mod tests {
         let test = TestDb::default();
         let btree = test.btree;
 
-        let mut engine = Engine::with_program(&ops, num_registers, btree);
+        let mut engine = Engine::with_program(&ops, num_registers, &btree);
         let yields = engine.run();
 
         assert_eq!(yields.len(), 3);
@@ -2339,7 +2339,7 @@ mod tests {
         let test = TestDb::default();
         let btree = test.btree;
 
-        let mut engine = Engine::with_program(&ops, num_registers, btree);
+        let mut engine = Engine::with_program(&ops, num_registers, &btree);
         let yields = engine.run();
 
         assert_eq!(yields.len(), 0);
@@ -2357,7 +2357,7 @@ mod tests {
         let test = TestDb::default();
         let btree = test.btree;
 
-        let mut engine = Engine::with_program(&ops, num_registers, btree);
+        let mut engine = Engine::with_program(&ops, num_registers, &btree);
         let yields = engine.run();
 
         assert_eq!(yields.len(), 1);
@@ -2385,7 +2385,7 @@ mod tests {
         let (ops, num_registers) = compile_plan(plan);
         let test = TestDb::default();
         let btree = test.btree;
-        let mut engine = Engine::with_program(&ops, num_registers, btree);
+        let mut engine = Engine::with_program(&ops, num_registers, &btree);
         engine.run()
     }
 
@@ -2894,7 +2894,7 @@ mod tests {
 
         let (ops, num_registers) = compile_plan(&plan);
 
-        let mut engine = Engine::with_program(&ops, num_registers, btree);
+        let mut engine = Engine::with_program(&ops, num_registers, &btree);
         let yields = engine.run();
 
         // Should yield a single row with count = 2
@@ -2927,12 +2927,8 @@ mod tests {
         };
 
         let (ops, num_registers) = compile_plan(&insert_plan);
-        let mut engine = Engine::with_program(&ops, num_registers, btree);
-        let insert_yields = engine.run();
+        let insert_yields = Engine::with_program(&ops, num_registers, &btree).run();
         assert_eq!(insert_yields[0][0], ScalarValue::Integer(3));
-
-        // Get btree back from engine
-        let btree = engine.take_btree().unwrap();
 
         // Second: SCAN to read back
         let scan_plan = LogicalPlan::Scan {
@@ -2942,7 +2938,7 @@ mod tests {
         };
 
         let (ops, num_registers) = compile_plan(&scan_plan);
-        let mut engine = Engine::with_program(&ops, num_registers, btree);
+        let mut engine = Engine::with_program(&ops, num_registers, &btree);
         let scan_yields = engine.run();
 
         assert_eq!(scan_yields.len(), 3);
@@ -2974,7 +2970,7 @@ mod tests {
         };
 
         let (ops, num_registers) = compile_plan(&plan);
-        let mut engine = Engine::with_program(&ops, num_registers, btree);
+        let mut engine = Engine::with_program(&ops, num_registers, &btree);
         let yields = engine.run();
 
         assert_eq!(yields.len(), 1);
@@ -3009,11 +3005,8 @@ mod tests {
             indexes: vec![index.clone()],
         };
         let (ops, num_regs) = compile_plan(&plan);
-        let mut engine = Engine::with_program(&ops, num_regs, btree);
-        let yields = engine.run();
+        let yields = Engine::with_program(&ops, num_regs, &btree).run();
         assert_eq!(yields[0][0], ScalarValue::Integer(1), "first insert count");
-
-        let btree = engine.take_btree().unwrap();
 
         // Second insert with the same indexed value must fail.
         let plan2 = LogicalPlan::Insert {
@@ -3025,7 +3018,7 @@ mod tests {
             indexes: vec![index],
         };
         let (ops2, num_regs2) = compile_plan(&plan2);
-        let mut engine2 = Engine::with_program(&ops2, num_regs2, btree);
+        let mut engine2 = Engine::with_program(&ops2, num_regs2, &btree);
         let result = engine2.run_result();
         assert!(
             matches!(result, Err(EngineError::ConstraintViolation(_))),
@@ -3063,7 +3056,7 @@ mod tests {
             indexes: vec![index],
         };
         let (ops, num_regs) = compile_plan(&plan);
-        let mut engine = Engine::with_program(&ops, num_regs, btree);
+        let mut engine = Engine::with_program(&ops, num_regs, &btree);
         let yields = engine.run();
         assert_eq!(yields[0][0], ScalarValue::Integer(3), "all 3 rows inserted");
     }
@@ -3093,7 +3086,7 @@ mod tests {
             indexes: vec![index],
         };
         let (ops, num_regs) = compile_plan(&plan);
-        let mut engine = Engine::with_program(&ops, num_regs, btree);
+        let mut engine = Engine::with_program(&ops, num_regs, &btree);
         let yields = engine.run();
         assert_eq!(yields[0][0], ScalarValue::Integer(2), "both rows inserted");
     }
@@ -3263,10 +3256,10 @@ mod tests {
     /// Run a plan that requires btree access.
     fn run_plan_with_btree(
         plan: &LogicalPlan,
-        btree: crate::storage::BTree,
+        btree: &crate::storage::BTree,
     ) -> Vec<Vec<ScalarValue>> {
         let (ops, num_registers) = compile_plan(plan);
-        let mut engine = Engine::with_program(&ops, num_registers, btree);
+        let mut engine = Engine::with_program(&ops, num_registers, &btree);
         engine.run()
     }
 
@@ -3295,7 +3288,7 @@ mod tests {
             on_eq_col0_col2(),
         );
 
-        let yields = run_plan_with_btree(&plan, btree);
+        let yields = run_plan_with_btree(&plan, &btree);
 
         assert_eq!(yields.len(), 3, "expected 3 rows, got: {:?}", yields);
         assert_eq!(
@@ -3360,7 +3353,7 @@ mod tests {
             on_eq_col0_col2(),
         );
 
-        let yields = run_plan_with_btree(&plan, btree);
+        let yields = run_plan_with_btree(&plan, &btree);
 
         assert_eq!(yields.len(), 2, "expected 2 rows, got: {:?}", yields);
         assert_eq!(yields[0][3], ScalarValue::Integer(200));
@@ -3390,7 +3383,7 @@ mod tests {
             on_true(),
         );
 
-        let yields = run_plan_with_btree(&plan, btree);
+        let yields = run_plan_with_btree(&plan, &btree);
         assert_eq!(yields.len(), 0);
     }
 
@@ -3417,7 +3410,7 @@ mod tests {
             on_true(),
         );
 
-        let yields = run_plan_with_btree(&plan, btree);
+        let yields = run_plan_with_btree(&plan, &btree);
         assert_eq!(yields.len(), 0);
     }
 
@@ -3516,7 +3509,7 @@ mod tests {
             left_column_count: 2,
         };
 
-        let yields = run_plan_with_btree(&plan, btree);
+        let yields = run_plan_with_btree(&plan, &btree);
 
         assert_eq!(yields.len(), 3, "expected 3 rows, got: {:?}", yields);
         assert_eq!(

--- a/src/db.rs
+++ b/src/db.rs
@@ -239,12 +239,7 @@ pub fn execute(sql: &str, catalog: &mut BTree) -> Result<ExecuteResult, ExecuteE
                 column_idxs,
             };
             let compiled = compiler::compile(&plan);
-            Engine::with_program(
-                compiled.operations(),
-                compiled.num_registers(),
-                catalog.clone(),
-            )
-            .run();
+            Engine::with_program(compiled.operations(), compiled.num_registers(), catalog).run();
 
             // 7. Add catalog entry
             catalog.insert_entry("index", &ci.index_name, &ci.table_name, index_rootpage, sql);
@@ -265,11 +260,8 @@ pub fn execute(sql: &str, catalog: &mut BTree) -> Result<ExecuteResult, ExecuteE
             let plan = planner::plan(stmt, catalog).map_err(ExecuteError::Plan)?;
             let mut compiled = compiler::compile(&plan);
             compiled.column_names = column_names;
-            let engine = Engine::with_program(
-                compiled.operations(),
-                compiled.num_registers(),
-                catalog.clone(),
-            );
+            let engine =
+                Engine::with_program(compiled.operations(), compiled.num_registers(), catalog);
             Ok(ExecuteResult::Query(QueryExecution::new(
                 engine,
                 compiled.column_names,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -59,12 +59,12 @@ impl Engine {
     /// Create an engine from a compiled program with a BTree for storage operations.
     pub fn from_compiled_with_btree(
         compiled: &crate::compiler::CompiledProgram,
-        btree: storage::BTree,
+        btree: &storage::BTree,
     ) -> Engine {
         let program: ProgramCode = compiled.operations.as_slice().into();
         let registers = Registers::new(compiled.num_registers);
         Engine {
-            btree: Some(btree),
+            btree: Some(btree.share()),
             registers,
             program,
         }
@@ -74,12 +74,12 @@ impl Engine {
     pub(crate) fn with_program(
         operations: &[Operation],
         num_registers: usize,
-        btree: storage::BTree,
+        btree: &storage::BTree,
     ) -> Engine {
         let program: ProgramCode = operations.into();
         let registers = Registers::new(num_registers);
         Engine {
-            btree: Some(btree),
+            btree: Some(btree.share()),
             registers,
             program,
         }
@@ -998,12 +998,12 @@ mod test {
         fn new_with_btree(
             operations: &[Operation],
             num_registers: usize,
-            btree: BTree,
+            btree: &BTree,
         ) -> TestHarness {
             let program = operations.into();
             let registers = Registers::new(num_registers);
             let mut engine = Engine::new(registers, program);
-            engine.btree = Some(btree);
+            engine.btree = Some(btree.share());
             TestHarness {
                 engine: engine,
                 yields: Vec::default(),
@@ -1512,7 +1512,7 @@ mod test {
                 Operation::Halt,
             ],
             3,
-            btree,
+            &btree,
         );
 
         harness.run();
@@ -1567,7 +1567,7 @@ mod test {
                 Operation::Halt,                      // End
             ],
             4,
-            btree,
+            &btree,
         );
 
         harness.run();
@@ -1626,7 +1626,7 @@ mod test {
                 Operation::Halt,                                 // 8
             ],
             5,
-            btree,
+            &btree,
         );
 
         harness.run();
@@ -1659,7 +1659,7 @@ mod test {
             Operation::Halt,
         ];
 
-        let mut engine = Engine::with_program(&ops, 1, btree);
+        let mut engine = Engine::with_program(&ops, 1, &btree);
         let yields = engine.run();
 
         assert_eq!(yields.len(), 1);
@@ -1703,7 +1703,7 @@ mod test {
             Operation::Halt,
         ];
 
-        let mut engine = Engine::with_program(&ops, 4, btree);
+        let mut engine = Engine::with_program(&ops, 4, &btree);
         let yields = engine.run();
 
         assert_eq!(yields.len(), 2);
@@ -1735,7 +1735,7 @@ mod test {
             Operation::Halt,
         ];
 
-        let mut engine = Engine::with_program(&ops, 3, btree);
+        let mut engine = Engine::with_program(&ops, 3, &btree);
         let yields = engine.run();
 
         assert_eq!(yields.len(), 0);
@@ -1773,7 +1773,7 @@ mod test {
                 Operation::Halt,                                       // 11
             ],
             7,
-            btree,
+            &btree,
         );
 
         harness.run();
@@ -1813,7 +1813,7 @@ mod test {
                 Operation::Halt,
             ],
             2,
-            btree,
+            &btree,
         );
 
         harness.run();
@@ -1846,7 +1846,7 @@ mod test {
                 Operation::Halt,
             ],
             4,
-            btree,
+            &btree,
         );
 
         harness.run();
@@ -1871,7 +1871,7 @@ mod test {
             Operation::Halt,
         ];
 
-        let mut engine = Engine::with_program(&ops, 1, btree);
+        let mut engine = Engine::with_program(&ops, 1, &btree);
         let yields = engine.run();
 
         assert_eq!(yields.len(), 3);
@@ -1910,7 +1910,7 @@ mod test {
             Operation::Halt,
         ];
 
-        let mut engine = Engine::with_program(&ops, 3, btree);
+        let mut engine = Engine::with_program(&ops, 3, &btree);
         let yields = engine.run();
 
         assert_eq!(yields.len(), 1);
@@ -1957,7 +1957,7 @@ mod test {
             Operation::Halt,
         ];
 
-        let mut engine = Engine::with_program(&ops, 3, TestDb::default().btree);
+        let mut engine = Engine::with_program(&ops, 3, &TestDb::default().btree);
         let yields = engine.run_with_limit(100);
 
         // Rows should come out in sorted order (ascending)
@@ -2007,7 +2007,7 @@ mod test {
             Operation::Halt,                       // addr 18
         ];
 
-        let mut engine = Engine::with_program(&ops, 3, TestDb::default().btree);
+        let mut engine = Engine::with_program(&ops, 3, &TestDb::default().btree);
         let yields = engine.run_with_limit(100);
 
         // Should yield 6 rows total: 3 from first pass + 3 from second pass
@@ -2091,7 +2091,7 @@ mod test {
             Operation::Halt,
         ];
 
-        let mut engine = Engine::with_program(&ops, 4, btree);
+        let mut engine = Engine::with_program(&ops, 4, &btree);
         let yields = engine.run_with_limit(100);
 
         // Should yield 3 rows in sorted order (ascending): 10, 20, 30
@@ -2181,7 +2181,7 @@ mod test {
             /*20*/ Operation::Halt,
         ];
 
-        let mut engine = Engine::with_program(&ops, 9, btree);
+        let mut engine = Engine::with_program(&ops, 9, &btree);
         let yields = engine.run_with_limit(100);
 
         // Should yield 3 rows sorted by name (column index 1)
@@ -2230,7 +2230,7 @@ mod test {
                 Operation::Halt,
             ],
             4,
-            btree,
+            &btree,
         );
         harness.run();
         assert_eq!(harness.num_yields(), 1);
@@ -2275,7 +2275,7 @@ mod test {
                 Operation::Halt,
             ],
             5,
-            btree,
+            &btree,
         );
         harness.run();
         assert_eq!(harness.num_yields(), 1);
@@ -2316,7 +2316,7 @@ mod test {
                 Operation::Halt,
             ],
             4,
-            btree,
+            &btree,
         );
         harness.run();
         assert_eq!(harness.num_yields(), 1);
@@ -2364,7 +2364,7 @@ mod test {
                 Operation::Halt,
             ],
             5,
-            btree,
+            &btree,
         );
         harness.run();
         assert_eq!(harness.num_yields(), 1);

--- a/src/repl/modes/engine.rs
+++ b/src/repl/modes/engine.rs
@@ -16,7 +16,7 @@ struct StepState {
 }
 
 impl StepState {
-    fn new(program: &CompiledProgram, btree: BTree) -> Self {
+    fn new(program: &CompiledProgram, btree: &BTree) -> Self {
         StepState {
             engine: Engine::from_compiled_with_btree(program, btree),
             pc: 0,
@@ -149,7 +149,7 @@ impl Mode for EngineMode {
 
                 let state = self
                     .step_state
-                    .get_or_insert_with(|| StepState::new(program, (*shared.btree).clone()));
+                    .get_or_insert_with(|| StepState::new(program, &shared.btree));
 
                 if state.halted {
                     return CommandResult::Message(
@@ -202,7 +202,7 @@ impl Mode for EngineMode {
 
                 let state = self
                     .step_state
-                    .get_or_insert_with(|| StepState::new(program, (*shared.btree).clone()));
+                    .get_or_insert_with(|| StepState::new(program, &shared.btree));
 
                 if state.halted {
                     return CommandResult::Message(
@@ -262,7 +262,7 @@ impl Mode for EngineMode {
 
             ["restart"] => match &self.program {
                 Some(p) => {
-                    self.step_state = Some(StepState::new(p, (*shared.btree).clone()));
+                    self.step_state = Some(StepState::new(p, &shared.btree));
                     CommandResult::Message("Execution restarted from instruction 0.".to_string())
                 }
                 None => CommandResult::Message(
@@ -281,8 +281,7 @@ impl Mode for EngineMode {
                 };
                 let source_sql = self.source_sql.clone().unwrap_or_default();
                 let logical_plan = self.logical_plan.as_ref().cloned();
-                let debugger =
-                    TuiDebugger::new(program, (*shared.btree).clone(), source_sql, logical_plan);
+                let debugger = TuiDebugger::new(program, &shared.btree, source_sql, logical_plan);
                 match debugger.run() {
                     Ok(()) => CommandResult::Message("Debugger exited.".to_string()),
                     Err(e) => CommandResult::Error(format!("TUI error: {e}")),

--- a/src/repl/tui_debugger.rs
+++ b/src/repl/tui_debugger.rs
@@ -29,9 +29,9 @@ enum StepOutcome {
     Stop, // Yield, Halt, or Error — caller should break
 }
 
-pub struct TuiDebugger {
+pub struct TuiDebugger<'a> {
     program: CompiledProgram,
-    btree: BTree,
+    btree: &'a BTree,
     engine: Engine,
     halted: bool,
     output_log: Vec<String>,
@@ -47,14 +47,14 @@ pub struct TuiDebugger {
     header_height: u16,
 }
 
-impl TuiDebugger {
+impl<'a> TuiDebugger<'a> {
     pub fn new(
         program: CompiledProgram,
-        btree: BTree,
+        btree: &'a BTree,
         source_sql: String,
         logical_plan: Option<LogicalPlan>,
     ) -> Self {
-        let engine = Engine::from_compiled_with_btree(&program, btree.clone());
+        let engine = Engine::from_compiled_with_btree(&program, btree);
 
         let sql_display: Vec<Line<'static>> = source_sql
             .lines()
@@ -62,7 +62,7 @@ impl TuiDebugger {
             .collect();
 
         let plan_strs: Vec<String> = if let Some(plan) = &logical_plan {
-            let schema = build_explain_schema(&btree.clone());
+            let schema = build_explain_schema(btree);
             format_plan(plan, &schema)
                 .into_iter()
                 .map(|(id, text)| format!("{id:>3}  {text}"))
@@ -193,7 +193,7 @@ impl TuiDebugger {
     }
 
     fn do_restart(&mut self) {
-        self.engine = Engine::from_compiled_with_btree(&self.program, self.btree.clone());
+        self.engine = Engine::from_compiled_with_btree(&self.program, self.btree);
         self.halted = false;
         self.output_log.clear();
         self.yielded_rows.clear();

--- a/src/storage/btree.rs
+++ b/src/storage/btree.rs
@@ -787,6 +787,17 @@ impl BTree {
         );
     }
 
+    /// Create a BTree sharing the underlying page store and rowid cache via Arc,
+    /// but with a fresh empty catalog cache. Used by the engine so it doesn't
+    /// inherit a deep-copied CatalogSnapshot from the caller.
+    pub fn share(&self) -> BTree {
+        BTree {
+            store: self.store.clone(),
+            rowid_cache: self.rowid_cache.clone(),
+            catalog_cache: RefCell::new(None),
+        }
+    }
+
     /// Invalidate the rowid cache entry for a given rootpage (call on DROP TABLE).
     pub fn invalidate_rowid_cache(&self, rootpage: u32) {
         self.rowid_cache.borrow_mut().remove(&rootpage);

--- a/src/storage/cell.rs
+++ b/src/storage/cell.rs
@@ -101,9 +101,7 @@ impl<'de> Visitor<'de> for CellDeserializeVisitor {
         A: serde::de::SeqAccess<'de>,
     {
         let key: serde_bytes::ByteBuf = seq.next_element()?.unwrap();
-        let payload: ValuesPayload = seq
-            .next_element()?
-            .unwrap_or(ValuesPayload::Array(vec![]));
+        let payload: ValuesPayload = seq.next_element()?.unwrap_or(ValuesPayload::Array(vec![]));
         let continuation: Option<u32> = seq.next_element()?;
 
         let (values, inline_bytes) = match payload {

--- a/src/storage/node.rs
+++ b/src/storage/node.rs
@@ -405,7 +405,6 @@ impl OverflowPage {
     }
 }
 
-
 #[cfg(test)]
 mod test {
     use std::collections::HashSet;
@@ -763,7 +762,6 @@ mod test {
         );
     }
 
-
     proptest! {
         #[test]
         fn test_interior_page_split(interior_num_edges in 4u64..150) {
@@ -778,5 +776,4 @@ mod test {
             prop_assert!(diff <= 1);
         }
     }
-
 }

--- a/src/storage/node_page_store.rs
+++ b/src/storage/node_page_store.rs
@@ -99,7 +99,6 @@ impl NodePageStore {
         Ok(())
     }
 
-
     /// Borrow a `&NodePage` from the cache (fetching from disk on miss).
     ///
     /// The returned reference must be dropped before calling `allocate`,
@@ -375,7 +374,10 @@ mod tests {
         store.write(id, leaf()).unwrap();
 
         // Page is dirty but not yet on disk — cold read from disk must fail.
-        assert!(store.dirty.contains(&id), "page should be dirty after write");
+        assert!(
+            store.dirty.contains(&id),
+            "page should be dirty after write"
+        );
         let bytes = store.pager.read_raw(id);
         let disk_result = decode_page(&bytes);
         assert!(
@@ -385,9 +387,15 @@ mod tests {
 
         // After flush the page is on disk and the dirty set is cleared.
         store.flush().unwrap();
-        assert!(!store.dirty.contains(&id), "dirty set should be empty after flush");
+        assert!(
+            !store.dirty.contains(&id),
+            "dirty set should be empty after flush"
+        );
         let bytes = store.pager.read_raw(id);
-        assert!(decode_page(&bytes).is_ok(), "page should be readable from disk after flush");
+        assert!(
+            decode_page(&bytes).is_ok(),
+            "page should be readable from disk after flush"
+        );
     }
 
     #[test]
@@ -413,6 +421,10 @@ mod tests {
         store.take(id).unwrap();
         store.write(id, leaf()).unwrap();
 
-        assert_eq!(store.dirty.len(), 1, "multiple writes to same page collapse to one dirty entry");
+        assert_eq!(
+            store.dirty.len(),
+            1,
+            "multiple writes to same page collapse to one dirty entry"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Add `BTree::share()` — Arc-clones `store` and `rowid_cache` but starts with a fresh empty `catalog_cache`. O(1) cost: two refcount bumps.
- Change `Engine::with_program` and `Engine::from_compiled_with_btree` to take `&BTree` instead of `BTree`. Internally they call `btree.share()`, so the engine still owns a `BTree` with no lifetime parameter.
- `TuiDebugger` gains a lifetime `'a` and stores `&'a BTree` instead of an owned clone; `do_restart` reuses the reference directly.
- `StepState` and `EngineMode` stay lifetime-free — their constructors now accept `&BTree` and share internally.
- All `catalog.clone()` calls in `db::execute` removed; test `take_btree()` patterns simplified to reuse `&btree`.

## Motivation

By the time `db::execute` reached the `Engine::with_program` call, the planner had already populated the `catalog_cache` (a `HashMap` of parsed tables and indexes). The old `BTree::clone()` copied that entire snapshot on every query. `BTree::share()` makes this O(1) regardless of catalog size.

## Test plan

- [x] `cargo test` — 465 tests pass, zero warnings
- [x] `cargo build 2>&1 | grep warning` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)