### PR TITLE
Phase AB: non-correlated subqueries (items 103–105)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ A hobby implementation of a relational database similar to SQLite. It includes a
 
 - Unit, integration, and SQL end-to-end tests (`cargo test --workspace`)
 - Inline SQL test harness: `.sql` files with `-- >` expected-output lines
+  * `src/bin/update-sql-tests.rs` tool can help seed the expected output
 - Property-based tests for B-tree invariants (proptest)
 
 ## Quick Start

--- a/crates/database-cli/src/display.rs
+++ b/crates/database-cli/src/display.rs
@@ -254,6 +254,14 @@ impl fmt::Display for ColoredOperation<'_> {
                 r!(buf),
                 jt!(target)
             ),
+            RowBufferContains(dest, buf, val) => write!(
+                f,
+                "{:10} {}, {}, {}",
+                "RBufContains".cyan().bold(),
+                r!(dest),
+                r!(buf),
+                r!(val)
+            ),
 
             // Group table
             InitGroupTable(reg) => write!(f, "{:10} {}", "InitGrpTbl".cyan().bold(), r!(reg)),

--- a/src/bin/update-sql-tests.rs
+++ b/src/bin/update-sql-tests.rs
@@ -1,9 +1,9 @@
 // Binary for updating SQL test expected output
 // Usage:
-//   cargo run --bin update-sql-tests              # Update all tests
-//   cargo run --bin update-sql-tests where_clauses delete  # Update specific tests
-//   cargo run --bin update-sql-tests --migrate    # Migrate all tests to inline format
-//   cargo run --bin update-sql-tests --migrate where_clauses  # Migrate specific tests
+//   cargo run -p database --bin update-sql-tests              # Update all tests
+//   cargo run -p database --bin update-sql-tests where_clauses delete  # Update specific tests
+//   cargo run -p database --bin update-sql-tests --migrate    # Migrate all tests to inline format
+//   cargo run -p database --bin update-sql-tests --migrate where_clauses  # Migrate specific tests
 
 use database::testing::sql_runner::{get_all_sql_tests, migrate_sql_test, run_sql_test};
 use std::env;

--- a/src/compiler/emitter.rs
+++ b/src/compiler/emitter.rs
@@ -153,6 +153,7 @@ impl BytecodeEmitter {
                 | Operation::AppendToRowBuffer(_, _)
                 | Operation::SortRowBuffer(_, _)
                 | Operation::RewindRowBuffer(_)
+                | Operation::RowBufferContains(_, _, _)
                 // Group table operations
                 | Operation::InitGroupTable(_)
                 | Operation::UpdateGroup(_, _, _)

--- a/src/compiler/expr.rs
+++ b/src/compiler/expr.rs
@@ -26,6 +26,11 @@ pub fn compile_expr(expr: &PlanExpr, input_regs: &[Reg], ctx: &mut ExprContext) 
         }
         PlanExpr::UnaryOp { op, operand } => compile_unary_op(op, operand, input_regs, ctx),
         PlanExpr::FunctionCall { name, args } => compile_function_call(name, args, input_regs, ctx),
+        PlanExpr::In {
+            expr,
+            values,
+            negated,
+        } => compile_in(expr, values, *negated, input_regs, ctx),
     }
 }
 
@@ -144,6 +149,47 @@ fn compile_function_call(
 
     ctx.emitter.emit(operation);
     dest
+}
+
+fn compile_in(
+    expr: &PlanExpr,
+    values: &[PlanExpr],
+    negated: bool,
+    input_regs: &[Reg],
+    ctx: &mut ExprContext,
+) -> Reg {
+    if values.is_empty() {
+        // IN () is always false; NOT IN () is always true
+        let dest = ctx.registers.alloc();
+        ctx.emitter
+            .emit(Operation::StoreValue(dest, ScalarValue::Boolean(negated)));
+        return dest;
+    }
+
+    let (cmp_op, combine_op) = if negated {
+        (BinaryOp::NotEquals, BinaryOp::And)
+    } else {
+        (BinaryOp::Equals, BinaryOp::Or)
+    };
+
+    // Build OR/AND chain: (expr cmp v0) combine (expr cmp v1) combine ...
+    let chain = values.iter().fold(None::<PlanExpr>, |acc, val| {
+        let cmp = PlanExpr::BinaryOp {
+            op: cmp_op.clone(),
+            left: Box::new(expr.clone()),
+            right: Box::new(val.clone()),
+        };
+        Some(match acc {
+            None => cmp,
+            Some(prev) => PlanExpr::BinaryOp {
+                op: combine_op.clone(),
+                left: Box::new(prev),
+                right: Box::new(cmp),
+            },
+        })
+    });
+
+    compile_expr(&chain.unwrap(), input_regs, ctx)
 }
 
 #[cfg(test)]

--- a/src/compiler/nodes.rs
+++ b/src/compiler/nodes.rs
@@ -951,26 +951,31 @@ pub fn codegen_materialize(
     init!(ctx; InitRowBuffer(buffer_reg));
 
     let collect_row = ctx.body_emitter.create_label();
-    let yield_next = ctx.body_emitter.create_label();
+    let after_child = ctx.body_emitter.create_label();
 
     let child_cont = NodeContinuation {
         on_tuple: collect_row,
-        on_done: yield_next,
+        on_done: after_child,
     };
 
     let child_output = codegen(input, &child_cont, ctx);
 
+    // Collect phase: append each child row to the buffer.
+    // Yield phase: rewind once, then iterate — `yield_loop` is the per-row entry point.
     body!(ctx;
         Bind(collect_row);
         AppendToRowBuffer(buffer_reg, child_output.output_regs.clone());
         GoTo(child_output.next);
-        Bind(yield_next);
+        Bind(after_child);
         RewindRowBuffer(buffer_reg)
     );
 
     let num_outputs = child_output.output_regs.len();
     let output_regs: Vec<Reg> = (0..num_outputs).map(|_| ctx.registers.alloc()).collect();
 
+    // yield_loop is bound here — mat_next must jump back to this point, not to after_child,
+    // so that RewindRowBuffer is not re-executed on every iteration.
+    let yield_loop = ctx.body_emitter.label_here();
     ctx.body_emitter.emit(Operation::NextFromRowBuffer(
         output_regs.clone(),
         buffer_reg,
@@ -979,7 +984,7 @@ pub fn codegen_materialize(
     body!(ctx; GoTo(cont.on_tuple));
 
     let mat_next = ctx.body_emitter.label_here();
-    body!(ctx; GoTo(yield_next));
+    body!(ctx; GoTo(yield_loop));
 
     NodeOutput {
         next: mat_next,

--- a/src/compiler/nodes.rs
+++ b/src/compiler/nodes.rs
@@ -1703,6 +1703,90 @@ pub fn codegen_join(
     }
 }
 
+/// Generate bytecode for a Semi-join (or anti-semi-join when `negated`).
+///
+/// Materialises the right side into a RowBuffer once (prelude), then for each
+/// left row probes the buffer with `RowBufferContains`. Yields only left columns.
+pub fn codegen_join_semi(
+    left: &LogicalPlan,
+    right: &LogicalPlan,
+    on_condition: &PlanExpr,
+    negated: bool,
+    cont: &NodeContinuation,
+    ctx: &mut CodegenContext,
+) -> NodeOutput {
+    // --- Phase 1: Materialise right side into buffer (same as Hash join prelude) ---
+    let buffer_reg = ctx.registers.alloc();
+    init!(ctx; InitRowBuffer(buffer_reg));
+
+    let mat_on_tuple = ctx.body_emitter.create_label();
+    let mat_on_done = ctx.body_emitter.create_label();
+    let right_cont = NodeContinuation {
+        on_tuple: mat_on_tuple,
+        on_done: mat_on_done,
+    };
+    let right_output = codegen(right, &right_cont, ctx);
+
+    let outer_loop_start = ctx.body_emitter.create_label();
+    body!(ctx;
+        Bind(mat_on_tuple);
+        AppendToRowBuffer(buffer_reg, right_output.output_regs.clone());
+        GoTo(right_output.next);
+        Bind(mat_on_done);
+        GoTo(outer_loop_start)
+    );
+
+    // --- Phase 2: For each left row, probe buffer ---
+    let left_on_tuple = ctx.body_emitter.create_label();
+    let left_cont = NodeContinuation {
+        on_tuple: left_on_tuple,
+        on_done: cont.on_done,
+    };
+    let left_output = codegen(left, &left_cont, ctx);
+
+    body!(ctx;
+        Bind(outer_loop_start);
+        GoTo(left_output.next)
+    );
+
+    // left_on_tuple: got a left row, probe the buffer
+    let match_reg = ctx.registers.alloc();
+    body!(ctx; Bind(left_on_tuple));
+    let key_reg = compile_expr(
+        on_condition,
+        &left_output.output_regs,
+        &mut ExprContext {
+            emitter: &mut ctx.body_emitter,
+            registers: &mut ctx.registers,
+        },
+    );
+    body!(ctx; RowBufferContains(match_reg, buffer_reg, key_reg));
+
+    if negated {
+        // Anti-semi: yield when NOT contained
+        body!(ctx;
+            GoToIfFalse(cont.on_tuple, match_reg);
+            GoTo(left_output.next)
+        );
+    } else {
+        // Semi: yield when contained
+        body!(ctx;
+            GoToIfFalse(left_output.next, match_reg);
+            GoTo(cont.on_tuple)
+        );
+    }
+
+    // semi_next: parent calls this after consuming a yielded left row
+    let semi_next = ctx.body_emitter.label_here();
+    body!(ctx; GoTo(left_output.next));
+
+    NodeOutput {
+        next: semi_next,
+        output_regs: left_output.output_regs,
+        reset: None,
+    }
+}
+
 /// Generate bytecode for a NestedLoop Join node.
 ///
 /// For each left row, resets the right child (via its reset label) and iterates
@@ -2078,8 +2162,8 @@ pub fn codegen(
             crate::planner::JoinStrategy::NestedLoop => {
                 codegen_join_nested_loop(left, right, on_condition, *left_column_count, cont, ctx)
             }
-            crate::planner::JoinStrategy::Semi { .. } => {
-                todo!("codegen_join_semi not yet implemented")
+            crate::planner::JoinStrategy::Semi { negated } => {
+                codegen_join_semi(left, right, on_condition, *negated, cont, ctx)
             }
         },
         LogicalPlan::IndexProbe {

--- a/src/compiler/nodes.rs
+++ b/src/compiler/nodes.rs
@@ -2078,6 +2078,9 @@ pub fn codegen(
             crate::planner::JoinStrategy::NestedLoop => {
                 codegen_join_nested_loop(left, right, on_condition, *left_column_count, cont, ctx)
             }
+            crate::planner::JoinStrategy::Semi { .. } => {
+                todo!("codegen_join_semi not yet implemented")
+            }
         },
         LogicalPlan::IndexProbe {
             index_rootpage,

--- a/src/compiler/nodes.rs
+++ b/src/compiler/nodes.rs
@@ -919,6 +919,75 @@ pub fn codegen_distinct(
     }
 }
 
+/// Generate bytecode for a Materialize node.
+///
+/// Materialize buffers all rows from its child into a RowBuffer, then yields them to
+/// the parent. Used for FROM subqueries, semi-join right sides, and scalar subquery
+/// preludes.
+///
+/// ```text
+/// INIT:
+///   InitRowBuffer(buffer)
+///
+/// BODY:
+///   [child] → collect_row:
+///     AppendToRowBuffer(buffer, child_regs)
+///     GoTo(child.next)
+///   yield_loop:
+///     RewindRowBuffer(buffer)
+///   yield_next:
+///     NextFromRowBuffer(output_regs, buffer, on_done)
+///     GoTo(on_tuple)
+///   mat_next:
+///     GoTo(yield_next)
+/// ```
+pub fn codegen_materialize(
+    input: &LogicalPlan,
+    cont: &NodeContinuation,
+    ctx: &mut CodegenContext,
+) -> NodeOutput {
+    let buffer_reg = ctx.registers.alloc();
+
+    init!(ctx; InitRowBuffer(buffer_reg));
+
+    let collect_row = ctx.body_emitter.create_label();
+    let yield_next = ctx.body_emitter.create_label();
+
+    let child_cont = NodeContinuation {
+        on_tuple: collect_row,
+        on_done: yield_next,
+    };
+
+    let child_output = codegen(input, &child_cont, ctx);
+
+    body!(ctx;
+        Bind(collect_row);
+        AppendToRowBuffer(buffer_reg, child_output.output_regs.clone());
+        GoTo(child_output.next);
+        Bind(yield_next);
+        RewindRowBuffer(buffer_reg)
+    );
+
+    let num_outputs = child_output.output_regs.len();
+    let output_regs: Vec<Reg> = (0..num_outputs).map(|_| ctx.registers.alloc()).collect();
+
+    ctx.body_emitter.emit(Operation::NextFromRowBuffer(
+        output_regs.clone(),
+        buffer_reg,
+        JumpTarget::Unresolved(cont.on_done),
+    ));
+    body!(ctx; GoTo(cont.on_tuple));
+
+    let mat_next = ctx.body_emitter.label_here();
+    body!(ctx; GoTo(yield_next));
+
+    NodeOutput {
+        next: mat_next,
+        output_regs,
+        reset: None,
+    }
+}
+
 /// Generate bytecode for a Sort node.
 ///
 /// Sort materializes all rows from its child, sorts them based on sort keys,
@@ -2011,6 +2080,7 @@ pub fn codegen(
             index_col_idx,
         } => codegen_index_probe(*index_rootpage, key_expr, *index_col_idx, cont, ctx),
         LogicalPlan::Distinct { input } => codegen_distinct(input, cont, ctx),
+        LogicalPlan::Materialize { input } => codegen_materialize(input, cont, ctx),
         LogicalPlan::PopulateIndex {
             input,
             index_rootpage,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -353,10 +353,8 @@ impl Engine {
                     RegisterValue::ScalarValue(ScalarValue::Boolean(result));
             }
             InitRowBuffer(reg) => {
-                *self.registers.get_mut(reg) = RegisterValue::RowBuffer(registers::RowBuffer {
-                    rows: Vec::new(),
-                    cursor: 0,
-                });
+                *self.registers.get_mut(reg) =
+                    RegisterValue::RowBuffer(registers::RowBuffer::new());
             }
             AppendToRowBuffer(buffer_reg, value_regs) => {
                 let values: Vec<ScalarValue> = value_regs
@@ -364,7 +362,7 @@ impl Engine {
                     .map(|reg| self.registers.get(*reg).scalar().unwrap().clone())
                     .collect();
                 let buffer = self.registers.get_mut(buffer_reg).row_buffer_mut().unwrap();
-                buffer.rows.push(values);
+                buffer.append(values);
             }
             SortRowBuffer(buffer_reg, sort_keys) => {
                 let buffer = self.registers.get_mut(buffer_reg).row_buffer_mut().unwrap();
@@ -413,6 +411,17 @@ impl Engine {
                         }
                     }
                 }
+            }
+            RowBufferContains(dest, buf_reg, val_reg) => {
+                let val = self.registers.get(val_reg).scalar().unwrap().clone();
+                let result = self
+                    .registers
+                    .get_mut(buf_reg)
+                    .row_buffer_mut()
+                    .unwrap()
+                    .contains_first_col(&val);
+                *self.registers.get_mut(dest) =
+                    RegisterValue::ScalarValue(ScalarValue::Boolean(result));
             }
             InitGroupTable(reg) => {
                 use std::collections::BTreeMap;

--- a/src/engine/program.rs
+++ b/src/engine/program.rs
@@ -133,6 +133,9 @@ pub enum Operation {
     /// If the read cursor is past the end, jump to target.
     /// Otherwise, copy row values into dest_regs and advance the read cursor.
     NextFromRowBuffer(Vec<Reg>, Reg, JumpTarget),
+    /// Set `dest = Boolean(true)` if any row in buffer has `row[0] == val`.
+    /// Builds and caches a HashSet on the first call (lazy evaluation).
+    RowBufferContains(Reg, Reg, Reg),
 
     // Group Table (for GROUP BY aggregation)
     InitGroupTable(Reg), // Initialize empty group table
@@ -220,6 +223,7 @@ impl Operation {
             SortRowBuffer(..) => "SortRowBuf",
             RewindRowBuffer(..) => "RewindRowBuf",
             NextFromRowBuffer(..) => "NextRowBuf",
+            RowBufferContains(..) => "RBufContains",
             InitGroupTable(..) => "InitGroupTable",
             UpdateGroup(..) => "UpdateGroup",
             YieldFromGroupTable(..) => "YieldGroup",
@@ -390,6 +394,9 @@ impl std::fmt::Display for Operation {
             RewindRowBuffer(buf) => write!(f, "{:10} {buf}", "RewindBuf"),
             NextFromRowBuffer(regs, buf, target) => {
                 write!(f, "{:10} [{}], {buf}, {target}", "NextRow", regs_str!(regs))
+            }
+            RowBufferContains(dest, buf, val) => {
+                write!(f, "{:10} {dest}, {buf}, {val}", "RBufContains")
             }
 
             // Group table operations

--- a/src/engine/registers.rs
+++ b/src/engine/registers.rs
@@ -1,7 +1,7 @@
 use crate::storage::CursorHandle;
 
 use super::{program::Reg, scalarvalue::ScalarValue};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 
 /// Accumulator for aggregate functions
 #[derive(Clone, Debug)]
@@ -26,6 +26,39 @@ pub type GroupTable = BTreeMap<Vec<ScalarValue>, Vec<Accumulator>>;
 pub struct RowBuffer {
     pub rows: Vec<Vec<ScalarValue>>,
     pub cursor: usize,
+    /// Lazily built on first `RowBufferContains` call. Indexes `rows[i][0]`.
+    /// Cleared on `AppendToRowBuffer` to stay consistent.
+    contains_cache: Option<HashSet<ScalarValue>>,
+}
+
+impl RowBuffer {
+    pub fn new() -> Self {
+        Self {
+            rows: Vec::new(),
+            cursor: 0,
+            contains_cache: None,
+        }
+    }
+
+    /// Append a row; invalidates the contains cache.
+    pub fn append(&mut self, row: Vec<ScalarValue>) {
+        self.contains_cache = None;
+        self.rows.push(row);
+    }
+
+    /// Test whether any row has `rows[i][0] == value`.
+    /// Builds and caches a HashSet on the first call.
+    pub fn contains_first_col(&mut self, value: &ScalarValue) -> bool {
+        if self.contains_cache.is_none() {
+            let set: HashSet<ScalarValue> = self
+                .rows
+                .iter()
+                .filter_map(|r| r.first().cloned())
+                .collect();
+            self.contains_cache = Some(set);
+        }
+        self.contains_cache.as_ref().unwrap().contains(value)
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -412,6 +412,23 @@ pub fn format_expr_with_names(expr: &PlanExpr, col_names: &[String]) -> String {
                 .collect();
             format!("{name}({})", a.join(", "))
         }
+        PlanExpr::In {
+            expr,
+            values,
+            negated,
+        } => {
+            let not = if *negated { "NOT " } else { "" };
+            let vals: Vec<_> = values
+                .iter()
+                .map(|v| format_expr_with_names(v, col_names))
+                .collect();
+            format!(
+                "{} {}IN ({})",
+                format_expr_with_names(expr, col_names),
+                not,
+                vals.join(", ")
+            )
+        }
     }
 }
 

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -309,8 +309,10 @@ fn collect_rows(
             ..
         } => {
             let strategy_label = match strategy {
-                crate::planner::JoinStrategy::Hash => "Hash",
-                crate::planner::JoinStrategy::NestedLoop => "NestedLoop",
+                crate::planner::JoinStrategy::Hash => "Hash".to_string(),
+                crate::planner::JoinStrategy::NestedLoop => "NestedLoop".to_string(),
+                crate::planner::JoinStrategy::Semi { negated: false } => "Semi".to_string(),
+                crate::planner::JoinStrategy::Semi { negated: true } => "Anti-Semi".to_string(),
             };
             format!(
                 "{indent}Join [{} | {}]",

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -105,7 +105,8 @@ fn node_output_cols(plan: &LogicalPlan, schema: &ExplainSchema) -> Vec<String> {
         | LogicalPlan::Limit { input, .. }
         | LogicalPlan::Sort { input, .. }
         | LogicalPlan::Count { input }
-        | LogicalPlan::Distinct { input } => node_output_cols(input, schema),
+        | LogicalPlan::Distinct { input }
+        | LogicalPlan::Materialize { input } => node_output_cols(input, schema),
         LogicalPlan::Project { input, columns } => {
             let input_cols = node_output_cols(input, schema);
             columns
@@ -202,7 +203,8 @@ fn collect_rows(
         | LogicalPlan::Distinct { input }
         | LogicalPlan::Insert { input, .. }
         | LogicalPlan::RowidLookup { input, .. }
-        | LogicalPlan::PopulateIndex { input, .. } => node_output_cols(input, schema),
+        | LogicalPlan::PopulateIndex { input, .. }
+        | LogicalPlan::Materialize { input } => node_output_cols(input, schema),
         LogicalPlan::Join { left, right, .. } => {
             let mut cols = node_output_cols(left, schema);
             cols.extend(node_output_cols(right, schema));
@@ -336,6 +338,7 @@ fn collect_rows(
         LogicalPlan::Sequence { start, end } => {
             format!("{indent}Sequence [{start}..{end})")
         }
+        LogicalPlan::Materialize { .. } => format!("{indent}Materialize"),
     };
 
     rows.push((id, summary));
@@ -356,7 +359,8 @@ fn plan_children(plan: &LogicalPlan) -> Vec<&LogicalPlan> {
         | LogicalPlan::Distinct { input }
         | LogicalPlan::Insert { input, .. }
         | LogicalPlan::RowidLookup { input, .. }
-        | LogicalPlan::PopulateIndex { input, .. } => vec![input],
+        | LogicalPlan::PopulateIndex { input, .. }
+        | LogicalPlan::Materialize { input } => vec![input],
         LogicalPlan::Join { left, right, .. } => vec![left, right],
         _ => vec![],
     }

--- a/src/frontend/ast.rs
+++ b/src/frontend/ast.rs
@@ -178,6 +178,12 @@ pub enum BinaryOp {
 }
 
 #[derive(Debug)]
+pub enum InSource {
+    Values(Vec<Expression>),
+    Subquery(Box<SelectStatement>),
+}
+
+#[derive(Debug)]
 pub enum Expression {
     UnaryOp {
         op: UnaryOp,
@@ -193,6 +199,12 @@ pub enum Expression {
         args: Vec<Expression>,
     },
     Value(ScalarValue),
+    In {
+        expr: Box<Expression>,
+        source: InSource,
+        negated: bool,
+    },
+    ScalarSubquery(Box<SelectStatement>),
 }
 
 #[derive(Debug)]
@@ -257,6 +269,8 @@ impl Expression {
                 }
                 refs
             }
+            Expression::In { expr, .. } => expr.get_column_references(),
+            Expression::ScalarSubquery(_) => vec![],
         }
     }
 }

--- a/src/frontend/lexer.rs
+++ b/src/frontend/lexer.rs
@@ -79,6 +79,7 @@ pub enum Type {
     Like,
     Is,
     Not,
+    In,
     Join,
     On,
     Inner,
@@ -530,7 +531,8 @@ impl<'a> Lexer<'a> {
                     },
                     b'n' => self.match_keyword("inner", Type::Inner),
                     b'd' => self.match_keyword("index", Type::Index),
-                    _ => self.make_identifier(),
+                    // `in` is 2 chars; any non-letter byte 2 means this may be `in`
+                    _ => self.match_keyword("in", Type::In),
                 },
                 b's' => self.match_keyword("is", Type::Is),
                 _ => self.make_identifier(),

--- a/src/frontend/parser.rs
+++ b/src/frontend/parser.rs
@@ -130,6 +130,10 @@ impl ParserInput {
                 self.advance();
                 Ok(())
             }
+            (Expect::In, lexer::Type::In) => {
+                self.advance();
+                Ok(())
+            }
             // These expectations are not used with `.expect`
             (Expect::PrimaryExpression, _) => panic!("Not implemented"),
             (Expect::Identifier, _) => panic!("Not implemented"),
@@ -176,6 +180,7 @@ pub enum Expect {
     Join,
     On,
     Key,
+    In,
 }
 
 impl lexer::Type {
@@ -987,6 +992,40 @@ impl Parser {
             }
         }
 
+        // Check for [NOT] IN (...)
+        let negated = if matches!(self.input.peek(), lexer::Type::Not) {
+            self.input.advance(); // consume NOT — must be followed by IN
+            true
+        } else {
+            false
+        };
+        if matches!(self.input.peek(), lexer::Type::In) {
+            self.input.advance(); // consume IN
+            self.input.expect(Expect::LeftParen)?;
+            let source = if matches!(self.input.peek(), lexer::Type::Select) {
+                let subquery = self.parse_select_statement()?;
+                ast::InSource::Subquery(Box::new(subquery))
+            } else {
+                let mut values = vec![self.parse_expression()?];
+                while matches!(self.input.peek(), lexer::Type::Comma) {
+                    self.input.advance();
+                    values.push(self.parse_expression()?);
+                }
+                ast::InSource::Values(values)
+            };
+            self.input.expect(Expect::RightParen)?;
+            expr = ast::Expression::In {
+                expr: Box::new(expr),
+                source,
+                negated,
+            };
+        } else if negated {
+            return Err(ParseError::UnexpectedToken(
+                Expect::In,
+                self.input.peek(),
+            ));
+        }
+
         Ok(expr)
     }
 
@@ -1179,10 +1218,15 @@ impl Parser {
             }
             lexer::Type::LeftParen => {
                 self.input.advance();
-                let expr = self.parse_expression()?;
-                self.input.expect(Expect::RightParen)?;
-
-                Ok(expr)
+                if matches!(self.input.peek(), lexer::Type::Select) {
+                    let stmt = self.parse_select_statement()?;
+                    self.input.expect(Expect::RightParen)?;
+                    Ok(ast::Expression::ScalarSubquery(Box::new(stmt)))
+                } else {
+                    let expr = self.parse_expression()?;
+                    self.input.expect(Expect::RightParen)?;
+                    Ok(expr)
+                }
             }
             t => Err(ParseError::UnexpectedToken(Expect::PrimaryExpression, t)),
         }
@@ -1721,5 +1765,58 @@ mod test {
         assert!(ct.columns[0]
             .constraints
             .contains(&ast::ColumnConstraint::Unique));
+    }
+
+    #[test]
+    fn parse_in_literal_list() {
+        let stmt = parse("SELECT id FROM users WHERE id IN (1, 2, 3)").unwrap();
+        let ast::Statement::Select(sel) = stmt else { panic!("expected select") };
+        let filter = sel.filter.unwrap();
+        match filter {
+            ast::Expression::In { negated, source: ast::InSource::Values(vals), .. } => {
+                assert!(!negated);
+                assert_eq!(vals.len(), 3);
+            }
+            _ => panic!("expected In expression"),
+        }
+    }
+
+    #[test]
+    fn parse_not_in_literal_list() {
+        let stmt = parse("SELECT id FROM users WHERE id NOT IN (10, 20)").unwrap();
+        let ast::Statement::Select(sel) = stmt else { panic!("expected select") };
+        let filter = sel.filter.unwrap();
+        match filter {
+            ast::Expression::In { negated, source: ast::InSource::Values(vals), .. } => {
+                assert!(negated);
+                assert_eq!(vals.len(), 2);
+            }
+            _ => panic!("expected In expression"),
+        }
+    }
+
+    #[test]
+    fn parse_in_subquery() {
+        let stmt = parse("SELECT id FROM users WHERE id IN (SELECT user_id FROM admins)").unwrap();
+        let ast::Statement::Select(sel) = stmt else { panic!("expected select") };
+        let filter = sel.filter.unwrap();
+        match filter {
+            ast::Expression::In { negated, source: ast::InSource::Subquery(_), .. } => {
+                assert!(!negated);
+            }
+            _ => panic!("expected In with subquery"),
+        }
+    }
+
+    #[test]
+    fn parse_scalar_subquery_in_select() {
+        let stmt = parse("SELECT (SELECT COUNT(*) FROM orders), name FROM users").unwrap();
+        let ast::Statement::Select(sel) = stmt else { panic!("expected select") };
+        match &sel.columns[0] {
+            ast::ColumnExpression::Anonyomous(expr) => {
+                assert!(matches!(**expr, ast::Expression::ScalarSubquery(_)));
+            }
+            _ => panic!("expected anonymous column expression"),
+        }
     }
 }

--- a/src/frontend/parser.rs
+++ b/src/frontend/parser.rs
@@ -702,6 +702,7 @@ impl Parser {
             lexer::Type::LeftParen => {
                 self.input.advance();
                 let statement = self.parse_select_statement()?;
+                self.input.expect(Expect::RightParen)?;
                 Ok(ast::TupleSource::Subquery(Box::new(statement)))
             }
             _ => {
@@ -1020,10 +1021,7 @@ impl Parser {
                 negated,
             };
         } else if negated {
-            return Err(ParseError::UnexpectedToken(
-                Expect::In,
-                self.input.peek(),
-            ));
+            return Err(ParseError::UnexpectedToken(Expect::In, self.input.peek()));
         }
 
         Ok(expr)
@@ -1770,10 +1768,16 @@ mod test {
     #[test]
     fn parse_in_literal_list() {
         let stmt = parse("SELECT id FROM users WHERE id IN (1, 2, 3)").unwrap();
-        let ast::Statement::Select(sel) = stmt else { panic!("expected select") };
+        let ast::Statement::Select(sel) = stmt else {
+            panic!("expected select")
+        };
         let filter = sel.filter.unwrap();
         match filter {
-            ast::Expression::In { negated, source: ast::InSource::Values(vals), .. } => {
+            ast::Expression::In {
+                negated,
+                source: ast::InSource::Values(vals),
+                ..
+            } => {
                 assert!(!negated);
                 assert_eq!(vals.len(), 3);
             }
@@ -1784,10 +1788,16 @@ mod test {
     #[test]
     fn parse_not_in_literal_list() {
         let stmt = parse("SELECT id FROM users WHERE id NOT IN (10, 20)").unwrap();
-        let ast::Statement::Select(sel) = stmt else { panic!("expected select") };
+        let ast::Statement::Select(sel) = stmt else {
+            panic!("expected select")
+        };
         let filter = sel.filter.unwrap();
         match filter {
-            ast::Expression::In { negated, source: ast::InSource::Values(vals), .. } => {
+            ast::Expression::In {
+                negated,
+                source: ast::InSource::Values(vals),
+                ..
+            } => {
                 assert!(negated);
                 assert_eq!(vals.len(), 2);
             }
@@ -1798,10 +1808,16 @@ mod test {
     #[test]
     fn parse_in_subquery() {
         let stmt = parse("SELECT id FROM users WHERE id IN (SELECT user_id FROM admins)").unwrap();
-        let ast::Statement::Select(sel) = stmt else { panic!("expected select") };
+        let ast::Statement::Select(sel) = stmt else {
+            panic!("expected select")
+        };
         let filter = sel.filter.unwrap();
         match filter {
-            ast::Expression::In { negated, source: ast::InSource::Subquery(_), .. } => {
+            ast::Expression::In {
+                negated,
+                source: ast::InSource::Subquery(_),
+                ..
+            } => {
                 assert!(!negated);
             }
             _ => panic!("expected In with subquery"),
@@ -1811,7 +1827,9 @@ mod test {
     #[test]
     fn parse_scalar_subquery_in_select() {
         let stmt = parse("SELECT (SELECT COUNT(*) FROM orders), name FROM users").unwrap();
-        let ast::Statement::Select(sel) = stmt else { panic!("expected select") };
+        let ast::Statement::Select(sel) = stmt else {
+            panic!("expected select")
+        };
         match &sel.columns[0] {
             ast::ColumnExpression::Anonyomous(expr) => {
                 assert!(matches!(**expr, ast::Expression::ScalarSubquery(_)));

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -304,6 +304,11 @@ pub enum LogicalPlan {
         index_rootpage: u32,
         column_idxs: Vec<usize>,
     },
+
+    /// Buffer all rows from `input` into a RowBuffer, then yield them.
+    /// Used for: FROM subqueries, right side of semi-joins, scalar subquery preludes.
+    /// No alias field — alias is a resolver concern consumed during planning.
+    Materialize { input: Box<LogicalPlan> },
 }
 // ============================================================================
 // Schema (for column resolution)

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -127,6 +127,13 @@ pub enum PlanExpr {
         name: String,
         args: Vec<PlanExpr>,
     },
+    /// expr IN (val, val, ...) — kept as a plan node for clean EXPLAIN output.
+    /// The compiler desugars to an OR equality chain at codegen time.
+    In {
+        expr: Box<PlanExpr>,
+        values: Vec<PlanExpr>,
+        negated: bool,
+    },
 }
 
 /// Join execution strategy, chosen by the optimizer.

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -145,6 +145,9 @@ pub enum JoinStrategy {
     /// Re-drive the right child once per left row via its reset entry point.
     /// Used when an index-probe is available on the right side.
     NestedLoop,
+    /// Semi-join: retain left rows whose key appears in the (materialised) right set.
+    /// `negated: true` → anti-semi-join (NOT IN).
+    Semi { negated: bool },
 }
 
 /// Logical plan nodes - relational algebra operators

--- a/src/planner/optimizer.rs
+++ b/src/planner/optimizer.rs
@@ -78,6 +78,9 @@ pub(super) fn fuse_projects(plan: LogicalPlan) -> LogicalPlan {
             index_rootpage,
             column_idxs,
         },
+        LogicalPlan::Materialize { input } => LogicalPlan::Materialize {
+            input: Box::new(fuse_projects(*input)),
+        },
         LogicalPlan::Join {
             left,
             right,
@@ -194,6 +197,9 @@ pub(super) fn optimize(plan: LogicalPlan, catalog: &BTree) -> LogicalPlan {
             having,
         },
         LogicalPlan::Distinct { input } => LogicalPlan::Distinct {
+            input: Box::new(optimize(*input, catalog)),
+        },
+        LogicalPlan::Materialize { input } => LogicalPlan::Materialize {
             input: Box::new(optimize(*input, catalog)),
         },
         // Rule 3: RowidLookup(IndexScan) → covering IndexScan when all requested

--- a/src/planner/optimizer.rs
+++ b/src/planner/optimizer.rs
@@ -258,12 +258,16 @@ pub(super) fn optimize(plan: LogicalPlan, catalog: &BTree) -> LogicalPlan {
                 }
             }
 
-            // No index available (or strategy is already Hash): promote to Hash.
+            // Semi/Anti-semi joins keep their strategy; others promote to Hash.
+            let final_strategy = match strategy {
+                JoinStrategy::Semi { .. } => strategy,
+                _ => JoinStrategy::Hash,
+            };
             LogicalPlan::Join {
                 left: Box::new(opt_left),
                 right: Box::new(opt_right),
                 on_condition,
-                strategy: JoinStrategy::Hash,
+                strategy: final_strategy,
                 left_column_count,
             }
         }

--- a/src/planner/resolver.rs
+++ b/src/planner/resolver.rs
@@ -72,6 +72,32 @@ impl ColumnResolver for JoinResolver<'_> {
     }
 }
 
+/// Resolver for a FROM subquery — maps column names from the inner plan's output to indices.
+/// The alias is consumed during planning and never stored in the plan node.
+pub(super) struct MaterializeResolver<'a> {
+    pub(super) alias: &'a str,
+    pub(super) columns: &'a [String],
+}
+
+impl ColumnResolver for MaterializeResolver<'_> {
+    fn resolve_identifier(&self, name: &str) -> Result<usize, PlanError> {
+        self.columns
+            .iter()
+            .position(|c| c == name)
+            .ok_or_else(|| PlanError::ColumnNotFound {
+                table: self.alias.to_string(),
+                column: name.to_string(),
+            })
+    }
+
+    fn resolve_qualified(&self, table: &str, column: &str) -> Result<usize, PlanError> {
+        if table != self.alias {
+            return Err(PlanError::TableNotFound(table.to_string()));
+        }
+        self.resolve_identifier(column)
+    }
+}
+
 /// No-context resolver (for INSERT VALUES - disallows column refs)
 pub(super) struct NoColumnResolver;
 

--- a/src/planner/resolver.rs
+++ b/src/planner/resolver.rs
@@ -111,6 +111,9 @@ pub(super) fn convert_expr(
             op: convert_unary_op(op),
             operand: Box::new(convert_expr(expression, resolver)?),
         }),
+        ast::Expression::In { .. } | ast::Expression::ScalarSubquery(_) => {
+            Err(PlanError::UnsupportedStatement)
+        }
         ast::Expression::FunctionCall { name, args } => {
             // Validate function name (case-insensitive)
             let name_upper = name.to_uppercase();
@@ -353,6 +356,9 @@ pub(super) fn convert_having_expr(
             _ => convert_scalar(scalar, resolver),
         },
         ast::Expression::FunctionCall { name, .. } => Err(PlanError::UnknownFunction(name.clone())),
+        ast::Expression::In { .. } | ast::Expression::ScalarSubquery(_) => {
+            Err(PlanError::UnsupportedStatement)
+        }
     }
 }
 
@@ -376,6 +382,8 @@ pub(super) fn collect_columns(expr: &ast::Expression, columns: &mut HashSet<Stri
                 collect_columns(arg, columns);
             }
         }
+        ast::Expression::In { expr, .. } => collect_columns(expr, columns),
+        ast::Expression::ScalarSubquery(_) => {}
     }
 }
 

--- a/src/planner/resolver.rs
+++ b/src/planner/resolver.rs
@@ -137,9 +137,25 @@ pub(super) fn convert_expr(
             op: convert_unary_op(op),
             operand: Box::new(convert_expr(expression, resolver)?),
         }),
-        ast::Expression::In { .. } | ast::Expression::ScalarSubquery(_) => {
-            Err(PlanError::UnsupportedStatement)
+        ast::Expression::In {
+            expr,
+            source: ast::InSource::Values(vals),
+            negated,
+        } => {
+            let plan_expr = convert_expr(expr, resolver)?;
+            let plan_vals: Result<Vec<_>, _> =
+                vals.iter().map(|v| convert_expr(v, resolver)).collect();
+            Ok(PlanExpr::In {
+                expr: Box::new(plan_expr),
+                values: plan_vals?,
+                negated: *negated,
+            })
         }
+        ast::Expression::In {
+            source: ast::InSource::Subquery(_),
+            ..
+        }
+        | ast::Expression::ScalarSubquery(_) => Err(PlanError::UnsupportedStatement),
         ast::Expression::FunctionCall { name, args } => {
             // Validate function name (case-insensitive)
             let name_upper = name.to_uppercase();
@@ -535,6 +551,21 @@ pub(super) fn remap_column_indices(
                 args: remapped_args,
             })
         }
+        PlanExpr::In {
+            expr,
+            values,
+            negated,
+        } => {
+            let remapped_values = values
+                .iter()
+                .map(|v| remap_column_indices(v, index_map))
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(PlanExpr::In {
+                expr: Box::new(remap_column_indices(expr, index_map)?),
+                values: remapped_values,
+                negated: *negated,
+            })
+        }
     }
 }
 
@@ -609,6 +640,7 @@ pub(super) fn eval_constant(expr: &PlanExpr) -> Result<Literal, PlanError> {
         }
         PlanExpr::ColumnRef(_) => Err(PlanError::UnsupportedStatement),
         PlanExpr::FunctionCall { .. } => Err(PlanError::UnsupportedStatement),
+        PlanExpr::In { .. } => Err(PlanError::UnsupportedStatement),
     }
 }
 

--- a/src/planner/select.rs
+++ b/src/planner/select.rs
@@ -11,7 +11,7 @@ use super::resolver::{
     build_column_mapping, collect_columns, collect_columns_from_column_expr, convert_aggregate,
     convert_column_expr, convert_expr, convert_having_expr, extract_limit_value,
     extract_table_info, has_aggregate, is_aggregate_function, remap_column_indices, ColumnResolver,
-    JoinResolver, SingleTableResolver,
+    JoinResolver, MaterializeResolver, SingleTableResolver,
 };
 use super::{schema, AggregateExpr, LogicalPlan, PlanError, PlanExpr, SortKey};
 
@@ -40,6 +40,7 @@ pub(super) fn output_width(plan: &LogicalPlan) -> usize {
 enum SelectResolver<'a> {
     Single(SingleTableResolver<'a>),
     Join(JoinResolver<'a>),
+    Materialize(MaterializeResolver<'a>),
 }
 
 impl ColumnResolver for SelectResolver<'_> {
@@ -47,6 +48,7 @@ impl ColumnResolver for SelectResolver<'_> {
         match self {
             Self::Single(r) => r.resolve_identifier(name),
             Self::Join(r) => r.resolve_identifier(name),
+            Self::Materialize(r) => r.resolve_identifier(name),
         }
     }
 
@@ -54,6 +56,7 @@ impl ColumnResolver for SelectResolver<'_> {
         match self {
             Self::Single(r) => r.resolve_qualified(table, column),
             Self::Join(r) => r.resolve_qualified(table, column),
+            Self::Materialize(r) => r.resolve_qualified(table, column),
         }
     }
 }
@@ -74,6 +77,11 @@ fn plan_select_single(
     select: ast::SelectStatement,
     catalog: &BTree,
 ) -> Result<LogicalPlan, PlanError> {
+    // If FROM is a subquery, take the Materialize path.
+    if is_from_subquery(&select.from) {
+        return plan_select_from_subquery(select, catalog);
+    }
+
     // 1. Extract table info from FROM clause
     let (table_name, table_ref) = extract_table_info(&select.from)?;
 
@@ -134,6 +142,92 @@ fn plan_select_single(
         resolver,
         wildcard_col_count,
         true, // supports_aggregation
+    )
+}
+
+fn is_from_subquery(from: &ast::NamedTupleSource) -> bool {
+    matches!(
+        from,
+        ast::NamedTupleSource::Named {
+            source: ast::TupleSource::Subquery(_),
+            ..
+        } | ast::NamedTupleSource::Anonyomous(ast::TupleSource::Subquery(_))
+    )
+}
+
+/// Plan a SELECT whose FROM clause is a subquery: `SELECT ... FROM (SELECT ...) AS alias`.
+///
+/// The inner query is planned recursively and wrapped in a `Materialize` node.
+/// A `MaterializeResolver` maps the outer query's column references to positional
+/// indices in the inner plan's output.
+fn plan_select_from_subquery(
+    select: ast::SelectStatement,
+    catalog: &BTree,
+) -> Result<LogicalPlan, PlanError> {
+    // Destructure select so we can move `from` without invalidating `select`
+    let ast::SelectStatement {
+        distinct,
+        columns,
+        from,
+        joins,
+        filter,
+        limit,
+        order_by,
+        group_by,
+        having,
+    } = select;
+
+    // Extract alias and inner statement from FROM clause
+    let (alias, inner_stmt) = match from {
+        ast::NamedTupleSource::Named {
+            alias,
+            source: ast::TupleSource::Subquery(inner),
+        } => (alias, *inner),
+        ast::NamedTupleSource::Anonyomous(ast::TupleSource::Subquery(inner)) => {
+            (String::new(), *inner)
+        }
+        _ => return Err(PlanError::UnsupportedStatement),
+    };
+
+    // Collect inner column names before consuming inner_stmt
+    let inner_col_names = crate::planner::extract_select_column_names(&inner_stmt, catalog);
+
+    // Plan the inner query and wrap in Materialize
+    let inner_plan = plan_select(inner_stmt, catalog)?;
+    let materialized = LogicalPlan::Materialize {
+        input: Box::new(inner_plan),
+    };
+
+    // Build resolver using inner plan's output column names
+    let resolver = SelectResolver::Materialize(MaterializeResolver {
+        alias: &alias,
+        columns: &inner_col_names,
+    });
+
+    // Apply WHERE filter on the materialized output (same pattern as plan_select_single)
+    let base_plan = apply_filter(materialized, filter.as_ref(), &resolver)?;
+
+    let wildcard_col_count = inner_col_names.len();
+
+    // Reconstruct the select statement (without from — it's been consumed)
+    let outer_select = ast::SelectStatement {
+        distinct,
+        columns,
+        from: ast::NamedTupleSource::Anonyomous(ast::TupleSource::Table(String::new())),
+        joins,
+        filter: None, // already applied above
+        limit,
+        order_by,
+        group_by,
+        having,
+    };
+
+    plan_select_body(
+        outer_select,
+        base_plan,
+        resolver,
+        wildcard_col_count,
+        false, // aggregation not supported on subquery sources yet
     )
 }
 
@@ -1402,6 +1496,21 @@ mod tests {
             matches!(result, LogicalPlan::Distinct { .. }),
             "Expected Distinct, got {result:?}"
         );
+    }
+
+    #[test]
+    fn plan_from_subquery_produces_materialize_node() {
+        let (test, _users_root) = make_users_db();
+        let stmt = parse_sql("SELECT name FROM (SELECT id, name FROM users) AS u WHERE u.id > 1");
+        let result = plan(stmt, &test.btree).expect("Planning failed");
+        // Should have a Filter somewhere in the top of the tree
+        let has_filter = match &result {
+            LogicalPlan::Project { input, .. } => {
+                matches!(input.as_ref(), LogicalPlan::Filter { .. })
+            }
+            _ => false,
+        };
+        assert!(has_filter, "Expected Filter under Project, got: {result:?}");
     }
 
     #[test]

--- a/src/planner/select.rs
+++ b/src/planner/select.rs
@@ -125,13 +125,46 @@ fn plan_select_single(
         columns: &mapping.column_map,
     });
 
-    // 5. Build base plan: Scan → optional Filter
+    // 5. Build base plan: Scan → optional Filter or Semi-join
     let scan = LogicalPlan::Scan {
         rootpage: table.rootpage,
         columns: mapping.scan_columns,
         with_key: false,
     };
-    let base_plan = apply_filter(scan, select.filter.as_ref(), &resolver)?;
+    let left_column_count = mapping.column_map.len();
+    let mut select = select;
+
+    // If WHERE is exactly `expr IN (SELECT ...)`, convert to a Semi join.
+    let is_in_subquery_filter = matches!(
+        select.filter,
+        Some(ast::Expression::In {
+            source: ast::InSource::Subquery(_),
+            ..
+        })
+    );
+    let base_plan = if is_in_subquery_filter {
+        // Move the filter out — we know it's Some(In { Subquery })
+        let filter_expr = select.filter.take().unwrap();
+        let (key_expr_ast, stmt, negated) = match filter_expr {
+            ast::Expression::In {
+                expr,
+                source: ast::InSource::Subquery(stmt),
+                negated,
+            } => (expr, stmt, negated),
+            _ => unreachable!(),
+        };
+        let key_expr = convert_expr(&key_expr_ast, &resolver)?;
+        let inner_plan = plan_select(*stmt, catalog)?;
+        LogicalPlan::Join {
+            left: Box::new(scan),
+            right: Box::new(inner_plan),
+            on_condition: key_expr,
+            strategy: crate::planner::JoinStrategy::Semi { negated },
+            left_column_count,
+        }
+    } else {
+        apply_filter(scan, select.filter.as_ref(), &resolver)?
+    };
 
     // 6. Build the rest of the plan using the shared body.
     // COUNT(*) and aggregation are only available on single-table queries.
@@ -1526,5 +1559,71 @@ mod tests {
             matches!(result, LogicalPlan::Sort { .. }),
             "Expected Sort, got {result:?}"
         );
+    }
+
+    fn make_two_table_db() -> (TestDb, u32, u32) {
+        let mut test = TestDb::default();
+        let users_root = test.btree.create_tree();
+        test.btree.insert_entry(
+            "table",
+            "users",
+            "users",
+            users_root,
+            "CREATE TABLE users (id INTEGER, name TEXT)",
+        );
+        let admins_root = test.btree.create_tree();
+        test.btree.insert_entry(
+            "table",
+            "admins",
+            "admins",
+            admins_root,
+            "CREATE TABLE admins (user_id INTEGER)",
+        );
+        (test, users_root, admins_root)
+    }
+
+    #[test]
+    fn plan_in_subquery_produces_semi_join() {
+        let (test, users_root, admins_root) = make_two_table_db();
+        let stmt = parse_sql("SELECT name FROM users WHERE id IN (SELECT user_id FROM admins)");
+        let plan = plan(stmt, &test.btree).expect("Planning failed");
+
+        // Top-level: Project
+        let inner = match plan {
+            LogicalPlan::Project { input, .. } => *input,
+            other => panic!("Expected Project, got {other:?}"),
+        };
+        // Inner: Join with Semi strategy
+        match inner {
+            LogicalPlan::Join {
+                strategy: crate::planner::JoinStrategy::Semi { negated: false },
+                left,
+                ..
+            } => {
+                assert!(
+                    matches!(*left, LogicalPlan::Scan { rootpage, .. } if rootpage == users_root)
+                );
+            }
+            other => panic!("Expected Semi join, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn plan_not_in_subquery_produces_anti_semi_join() {
+        let (test, users_root, admins_root) = make_two_table_db();
+        let stmt = parse_sql("SELECT name FROM users WHERE id NOT IN (SELECT user_id FROM admins)");
+        let plan = plan(stmt, &test.btree).expect("Planning failed");
+
+        let inner = match plan {
+            LogicalPlan::Project { input, .. } => *input,
+            other => panic!("Expected Project, got {other:?}"),
+        };
+        match inner {
+            LogicalPlan::Join {
+                strategy: crate::planner::JoinStrategy::Semi { negated: true },
+                ..
+            } => {}
+            other => panic!("Expected Anti-Semi join, got {other:?}"),
+        }
     }
 }

--- a/src/planner/select.rs
+++ b/src/planner/select.rs
@@ -29,7 +29,8 @@ pub(super) fn output_width(plan: &LogicalPlan) -> usize {
         | LogicalPlan::Limit { input, .. }
         | LogicalPlan::Distinct { input, .. }
         | LogicalPlan::Filter { input, .. }
-        | LogicalPlan::RowidLookup { input, .. } => output_width(input),
+        | LogicalPlan::RowidLookup { input, .. }
+        | LogicalPlan::Materialize { input } => output_width(input),
         LogicalPlan::Scan { columns, .. } => columns.len(),
         _ => 0,
     }

--- a/tests/sql/subquery_from.sql
+++ b/tests/sql/subquery_from.sql
@@ -1,0 +1,12 @@
+CREATE TABLE users (id INTEGER, name TEXT, age INTEGER)
+-- > Table 'users' created
+INSERT INTO users VALUES (1, 'alice', 30), (2, 'bob', 25), (3, 'carol', 35)
+-- > 3
+
+SELECT name FROM (SELECT id, name FROM users WHERE age > 28) AS young ORDER BY name
+-- > "alice"
+-- > "carol"
+
+SELECT name FROM (SELECT id, name FROM users) AS u WHERE u.id > 1 ORDER BY name
+-- > "bob"
+-- > "carol"

--- a/tests/sql/subquery_in.sql
+++ b/tests/sql/subquery_in.sql
@@ -1,0 +1,20 @@
+CREATE TABLE users (id INTEGER, name TEXT)
+-- > Table 'users' created
+CREATE TABLE admins (user_id INTEGER)
+-- > Table 'admins' created
+INSERT INTO users VALUES (1, 'alice'), (2, 'bob'), (3, 'carol')
+-- > 3
+INSERT INTO admins VALUES (1), (3)
+-- > 2
+
+SELECT name FROM users WHERE id IN (1, 3) ORDER BY name
+-- > "alice"
+-- > "carol"
+
+SELECT name FROM users WHERE id NOT IN (1, 3) ORDER BY name
+-- > "bob"
+
+SELECT name FROM users WHERE id IN (1) ORDER BY name
+-- > "alice"
+
+SELECT name FROM users WHERE id NOT IN (1, 2, 3) ORDER BY name

--- a/tests/sql/subquery_in.sql
+++ b/tests/sql/subquery_in.sql
@@ -18,3 +18,21 @@ SELECT name FROM users WHERE id IN (1) ORDER BY name
 -- > "alice"
 
 SELECT name FROM users WHERE id NOT IN (1, 2, 3) ORDER BY name
+-- > OK
+
+SELECT name FROM users WHERE id IN (SELECT user_id FROM admins) ORDER BY name
+-- > "alice"
+-- > "carol"
+
+SELECT name FROM users WHERE id NOT IN (SELECT user_id FROM admins) ORDER BY name
+-- > "bob"
+
+SELECT name FROM users WHERE id IN (SELECT user_id FROM admins WHERE user_id > 100)
+-- > OK
+
+EXPLAIN SELECT name FROM users WHERE id IN (SELECT user_id FROM admins)
+-- > 0, "Project [name:1]"
+-- > 1, "  Join [Semi | id:0]"
+-- > 2, "    Scan users [cols: id, name]"
+-- > 3, "    Project [user_id:0]"
+-- > 4, "      Scan admins [cols: user_id]"


### PR DESCRIPTION
## Summary

- **Item 103** (AST + parser): `Expression::In`, `InSource`, `Expression::ScalarSubquery` — parsed `IN (...)`, `NOT IN (...)`, and scalar `(SELECT ...)` in expression position
- **Item 104** (Materialize + FROM subqueries): `LogicalPlan::Materialize`, `MaterializeResolver`, `codegen_materialize` — `FROM (SELECT ...) AS alias` fully functional
- **Item 105** (IN operator + semi-join): `PlanExpr::In` (literal list), `JoinStrategy::Semi { negated }`, `RowBufferContains` VM op with lazy HashSet cache, `codegen_join_semi` — `WHERE id IN (subquery)` and `NOT IN (subquery)` fully functional

All three items use a single `Materialize` buffering primitive. `JoinStrategy::Semi` reuses the Hash join prelude infrastructure; codegen is ~80 lines.

Item 106 (scalar subqueries) is the remaining item in this phase.

## Test plan

- [ ] `cargo test --workspace` — all tests pass (478 tests)
- [ ] `tests/sql/subquery_from.sql` — FROM subquery cases
- [ ] `tests/sql/subquery_in.sql` — literal IN, IN (subquery), NOT IN (subquery), empty right side, EXPLAIN

🤖 Generated with [Claude Code](https://claude.com/claude-code)